### PR TITLE
 Refactor JoinClause to use a Clause join clause

### DIFF
--- a/column_test.go
+++ b/column_test.go
@@ -39,9 +39,9 @@ func TestColumn(t *testing.T) {
 
 	// like
 	like := col.Like("s%")
-	likeSqlite, likeBindingsSqlite := asSQL(like, sqlite)
-	likeMysql, likeBindingsMysql := asSQL(like, mysql)
-	likePostgres, likeBindingsPostgres := asSQL(like, postgres)
+	likeSqlite, likeBindingsSqlite := asSQLBinds(like, sqlite)
+	likeMysql, likeBindingsMysql := asSQLBinds(like, mysql)
+	likePostgres, likeBindingsPostgres := asSQLBinds(like, postgres)
 
 	assert.Equal(t, "id LIKE ?", likeSqlite)
 	assert.Equal(t, []interface{}{"s%"}, likeBindingsSqlite)
@@ -52,9 +52,9 @@ func TestColumn(t *testing.T) {
 
 	// not in
 	notIn := col.NotIn("id1", "id2")
-	notInSqlite, likeBindingsSqlite := asSQL(notIn, sqlite)
-	notInMysql, likeBindingsMysql := asSQL(notIn, mysql)
-	notInPostgres, likeBindingsPostgres := asSQL(notIn, postgres)
+	notInSqlite, likeBindingsSqlite := asSQLBinds(notIn, sqlite)
+	notInMysql, likeBindingsMysql := asSQLBinds(notIn, mysql)
+	notInPostgres, likeBindingsPostgres := asSQLBinds(notIn, postgres)
 
 	assert.Equal(t, "id NOT IN (?, ?)", notInSqlite)
 	assert.Equal(t, []interface{}{"id1", "id2"}, likeBindingsSqlite)
@@ -67,9 +67,9 @@ func TestColumn(t *testing.T) {
 
 	// in
 	in := col.In("id1", "id2")
-	inSqlite, likeBindingsSqlite := asSQL(in, sqlite)
-	inMysql, likeBindingsMysql := asSQL(in, mysql)
-	inPostgres, likeBindingsPostgres := asSQL(in, postgres)
+	inSqlite, likeBindingsSqlite := asSQLBinds(in, sqlite)
+	inMysql, likeBindingsMysql := asSQLBinds(in, mysql)
+	inPostgres, likeBindingsPostgres := asSQLBinds(in, postgres)
 
 	assert.Equal(t, "id IN (?, ?)", inSqlite)
 	assert.Equal(t, []interface{}{"id1", "id2"}, likeBindingsSqlite)
@@ -82,9 +82,9 @@ func TestColumn(t *testing.T) {
 
 	// not eq
 	notEq := col.NotEq("id1")
-	notEqSqlite, likeBindingsSqlite := asSQL(notEq, sqlite)
-	notEqMysql, likeBindingsMysql := asSQL(notEq, mysql)
-	notEqPostgres, likeBindingsPostgres := asSQL(notEq, postgres)
+	notEqSqlite, likeBindingsSqlite := asSQLBinds(notEq, sqlite)
+	notEqMysql, likeBindingsMysql := asSQLBinds(notEq, mysql)
+	notEqPostgres, likeBindingsPostgres := asSQLBinds(notEq, postgres)
 
 	assert.Equal(t, "id != ?", notEqSqlite)
 	assert.Equal(t, []interface{}{"id1"}, likeBindingsSqlite)
@@ -97,9 +97,9 @@ func TestColumn(t *testing.T) {
 
 	// eq
 	eq := col.Eq("id1")
-	eqSqlite, likeBindingsSqlite := asSQL(eq, sqlite)
-	eqMysql, likeBindingsMysql := asSQL(eq, mysql)
-	eqPostgres, likeBindingsPostgres := asSQL(eq, postgres)
+	eqSqlite, likeBindingsSqlite := asSQLBinds(eq, sqlite)
+	eqMysql, likeBindingsMysql := asSQLBinds(eq, mysql)
+	eqPostgres, likeBindingsPostgres := asSQLBinds(eq, postgres)
 
 	assert.Equal(t, "id = ?", eqSqlite)
 	assert.Equal(t, []interface{}{"id1"}, likeBindingsSqlite)
@@ -112,9 +112,9 @@ func TestColumn(t *testing.T) {
 
 	// gt
 	gt := col.Gt("id1")
-	gtSqlite, likeBindingsSqlite := asSQL(gt, sqlite)
-	gtMysql, likeBindingsMysql := asSQL(gt, mysql)
-	gtPostgres, likeBindingsPostgres := asSQL(gt, postgres)
+	gtSqlite, likeBindingsSqlite := asSQLBinds(gt, sqlite)
+	gtMysql, likeBindingsMysql := asSQLBinds(gt, mysql)
+	gtPostgres, likeBindingsPostgres := asSQLBinds(gt, postgres)
 
 	assert.Equal(t, "id > ?", gtSqlite)
 	assert.Equal(t, []interface{}{"id1"}, likeBindingsSqlite)
@@ -127,9 +127,9 @@ func TestColumn(t *testing.T) {
 
 	// lt
 	lt := col.Lt("id1")
-	ltSqlite, likeBindingsSqlite := asSQL(lt, sqlite)
-	ltMysql, likeBindingsMysql := asSQL(lt, mysql)
-	ltPostgres, likeBindingsPostgres := asSQL(lt, postgres)
+	ltSqlite, likeBindingsSqlite := asSQLBinds(lt, sqlite)
+	ltMysql, likeBindingsMysql := asSQLBinds(lt, mysql)
+	ltPostgres, likeBindingsPostgres := asSQLBinds(lt, postgres)
 
 	assert.Equal(t, "id < ?", ltSqlite)
 	assert.Equal(t, []interface{}{"id1"}, likeBindingsSqlite)
@@ -142,9 +142,9 @@ func TestColumn(t *testing.T) {
 
 	// gte
 	gte := col.Gte("id1")
-	gteSqlite, likeBindingsSqlite := asSQL(gte, sqlite)
-	gteMysql, likeBindingsMysql := asSQL(gte, mysql)
-	gtePostgres, likeBindingsPostgres := asSQL(gte, postgres)
+	gteSqlite, likeBindingsSqlite := asSQLBinds(gte, sqlite)
+	gteMysql, likeBindingsMysql := asSQLBinds(gte, mysql)
+	gtePostgres, likeBindingsPostgres := asSQLBinds(gte, postgres)
 
 	assert.Equal(t, "id >= ?", gteSqlite)
 	assert.Equal(t, []interface{}{"id1"}, likeBindingsSqlite)
@@ -157,9 +157,9 @@ func TestColumn(t *testing.T) {
 
 	// lte
 	lte := col.Lte("id1")
-	lteSqlite, likeBindingsSqlite := asSQL(lte, sqlite)
-	lteMysql, likeBindingsMysql := asSQL(lte, mysql)
-	ltePostgres, likeBindingsPostgres := asSQL(lte, postgres)
+	lteSqlite, likeBindingsSqlite := asSQLBinds(lte, sqlite)
+	lteMysql, likeBindingsMysql := asSQLBinds(lte, mysql)
+	ltePostgres, likeBindingsPostgres := asSQLBinds(lte, postgres)
 
 	assert.Equal(t, "id <= ?", lteSqlite)
 	assert.Equal(t, []interface{}{"id1"}, likeBindingsSqlite)

--- a/compiler.go
+++ b/compiler.go
@@ -171,15 +171,16 @@ func (c SQLCompiler) VisitInsert(context *CompilerContext, insert InsertStmt) st
 	return sql
 }
 
+// VisitJoin compiles a JOIN (ON) clause
 func (c SQLCompiler) VisitJoin(context *CompilerContext, join JoinClause) string {
 	sql := fmt.Sprintf(
 		"%s\n%s %s",
-		join.left.Accept(context),
-		join.joinType,
-		join.right.Accept(context),
+		join.Left.Accept(context),
+		join.JoinType,
+		join.Right.Accept(context),
 	)
-	if (join.leftCol.Name != "") || (join.rightCol.Name != "") {
-		sql += " ON " + join.leftCol.Accept(context) + " = " + join.rightCol.Accept(context)
+	if join.OnClause != nil {
+		sql += " ON " + join.OnClause.Accept(context)
 	}
 
 	return sql

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -30,6 +30,21 @@ var compileTests = []struct {
 }{
 	{SQLText("1"), "1", emptyBinds},
 	{
+		Join("LEFT JOIN", TTGroup, TTUser),
+		"group\nLEFT JOIN user ON user.main_group_id = group.id",
+		emptyBinds,
+	},
+	{
+		Join("LEFT JOIN", TTGroup, TTUser, TTGroup.C("id").Eq(TTUser.C("id"))),
+		"group\nLEFT JOIN user ON group.id = user.id",
+		emptyBinds,
+	},
+	{
+		Join("LEFT JOIN", TTGroup, TTUser, TTGroup.C("id"), TTUser.C("id")),
+		"group\nLEFT JOIN user ON group.id = user.id",
+		emptyBinds,
+	},
+	{
 		Exists(Select(TTGroup.C("name")).From(TTGroup).Where(TTGroup.C("id").Eq(TTUser.C("main_group_id")))),
 		"EXISTS(SELECT group.name\nFROM group\nWHERE group.id = user.main_group_id)",
 		emptyBinds,

--- a/select.go
+++ b/select.go
@@ -47,8 +47,8 @@ func (s SelectStmt) Where(clause Clause) SelectStmt {
 }
 
 // InnerJoin appends an inner join clause to the select statement
-func (s SelectStmt) InnerJoin(right Selectable, onClauses ...Clause) SelectStmt {
-	return s.From(Join("INNER JOIN", s.from, right, onClauses...))
+func (s SelectStmt) InnerJoin(right Selectable, onClause ...Clause) SelectStmt {
+	return s.From(Join("INNER JOIN", s.from, right, onClause...))
 }
 
 // CrossJoin appends an cross join clause to the select statement
@@ -57,13 +57,13 @@ func (s SelectStmt) CrossJoin(right Selectable) SelectStmt {
 }
 
 // LeftJoin appends an left outer join clause to the select statement
-func (s SelectStmt) LeftJoin(right Selectable, leftCol ColumnElem, rightCol ColumnElem) SelectStmt {
-	return s.From(Join("LEFT OUTER JOIN", s.from, right, leftCol, rightCol))
+func (s SelectStmt) LeftJoin(right Selectable, onClause ...Clause) SelectStmt {
+	return s.From(Join("LEFT OUTER JOIN", s.from, right, onClause...))
 }
 
 // RightJoin appends a right outer join clause to select statement
-func (s SelectStmt) RightJoin(right Selectable, leftCol ColumnElem, rightCol ColumnElem) SelectStmt {
-	return s.From(Join("RIGHT OUTER JOIN", s.from, right, leftCol, rightCol))
+func (s SelectStmt) RightJoin(right Selectable, onClause ...Clause) SelectStmt {
+	return s.From(Join("RIGHT OUTER JOIN", s.from, right, onClause...))
 }
 
 // OrderBy generates an OrderByClause and sets select statement's orderbyclause

--- a/select.go
+++ b/select.go
@@ -130,13 +130,24 @@ type joinOnClauseCandidate struct {
 	target TableElem
 }
 
+func getTable(sel Selectable) (TableElem, bool) {
+	switch t := sel.(type) {
+	case TableElem:
+		return t, true
+	case *TableElem:
+		return *t, true
+	default:
+		return TableElem{}, false
+	}
+}
+
 // GuessJoinOnClause finds a join 'ON' clause between two tables
 func GuessJoinOnClause(left Selectable, right Selectable) Clause {
-	leftTable, ok := left.(TableElem)
+	leftTable, ok := getTable(left)
 	if !ok {
 		panic("left Selectable is not a Table: Cannot guess join onClause")
 	}
-	rightTable, ok := right.(TableElem)
+	rightTable, ok := getTable(right)
 	if !ok {
 		panic("right Selectable is not a Table: Cannot guess join onClause")
 	}

--- a/select_test.go
+++ b/select_test.go
@@ -261,6 +261,59 @@ LEFT OUTER JOIN "sessions" AS "newname" ON "u"."id" = "newname"."user_id"
 WHERE "newname"."auth_token" = $1;`, st.SQL())
 }
 
+func (suite *SelectTestSuite) TestGuessJoinOnClause() {
+	t1 := Table(
+		"t1",
+		Column("c1", Int()),
+		Column("c2", Int()),
+	)
+	t2 := Table(
+		"t2",
+		Column("c1", Int()),
+		Column("c2", Int()),
+	)
+	t3 := Table(
+		"t3",
+		Column("c1", Int()),
+		Column("c2", Int()),
+		ForeignKey("c1").References("t1", "c1"),
+		ForeignKey("c1").References("t2", "c1"),
+		ForeignKey("c2").References("t2", "c2"),
+	)
+	t4 := Table(
+		"t4",
+		Column("c1", Int()),
+		Column("c2", Int()),
+		ForeignKey("c1", "c2").References("t1", "c1", "c2"),
+	)
+
+	assert.Panics(suite.T(), func() {
+		GuessJoinOnClause(t1, Alias("tt", t3))
+	})
+
+	assert.Panics(suite.T(), func() {
+		GuessJoinOnClause(Alias("tt", t3), t2)
+	})
+
+	assert.Panics(suite.T(), func() {
+		GuessJoinOnClause(t1, t2)
+	})
+
+	assert.Equal(suite.T(), "t3.c1 = t1.c1", asDefSQL(GuessJoinOnClause(t3, t1)))
+	assert.Equal(suite.T(), "t3.c1 = t1.c1", asDefSQL(GuessJoinOnClause(t1, t3)))
+	assert.Equal(suite.T(), "(t4.c1 = t1.c1 AND t4.c2 = t1.c2)", asDefSQL(GuessJoinOnClause(t4, t1)))
+
+	assert.Panics(suite.T(), func() {
+		GuessJoinOnClause(t2, t3)
+	})
+}
+
+func (suite *SelectTestSuite) TestMakeJoinOnClause() {
+	assert.Panics(suite.T(), func() {
+		MakeJoinOnClause(TableElem{}, TableElem{}, And(), And(), And())
+	})
+}
+
 func TestSelectTestSuite(t *testing.T) {
 	suite.Run(t, new(SelectTestSuite))
 }

--- a/select_test.go
+++ b/select_test.go
@@ -296,7 +296,7 @@ func (suite *SelectTestSuite) TestGuessJoinOnClause() {
 	})
 
 	assert.Panics(suite.T(), func() {
-		GuessJoinOnClause(t1, t2)
+		GuessJoinOnClause(t1, &t2)
 	})
 
 	assert.Equal(suite.T(), "t3.c1 = t1.c1", asDefSQL(GuessJoinOnClause(t3, t1)))

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -5,7 +5,20 @@ import (
 	"testing"
 )
 
-func asSQL(clause Clause, dialect Dialect) (string, []interface{}) {
+func asDefSQL(clause Clause) string {
+	return asSQL(clause, NewDialect("default"))
+}
+
+func asDefSQLBinds(clause Clause) (string, []interface{}) {
+	return asSQLBinds(clause, NewDialect("default"))
+}
+
+func asSQL(clause Clause, dialect Dialect) string {
+	sql, _ := asSQLBinds(clause, dialect)
+	return sql
+}
+
+func asSQLBinds(clause Clause, dialect Dialect) (string, []interface{}) {
 	defer dialect.Reset()
 	ctx := NewCompilerContext(dialect)
 	return clause.Accept(ctx), ctx.Binds


### PR DESCRIPTION
The JoinClause can now use any Clause as a "ON" clause.

Additionaly, the join clause between two tables can be guessed
automatically it one and only one foreign key links them.

