### PR TITLE
Fix single col pkey creation

### DIFF
--- a/column.go
+++ b/column.go
@@ -15,9 +15,10 @@ func Column(name string, t TypeElem) ColumnElem {
 
 // ColumnOptions holds options for a column
 type ColumnOptions struct {
-	AutoIncrement bool
-	PrimaryKey    bool
-	Unique        bool
+	AutoIncrement    bool
+	PrimaryKey       bool
+	InlinePrimaryKey bool
+	Unique           bool
 }
 
 // ColumnElem is the definition of any columns defined in a table
@@ -42,6 +43,12 @@ func (c ColumnElem) PrimaryKey() ColumnElem {
 	return c
 }
 
+// inlinePrimaryKey flags the column so it will inline the primary key constraint
+func (c ColumnElem) inlinePrimaryKey() ColumnElem {
+	c.Options.InlinePrimaryKey = true
+	return c
+}
+
 // String returns the column element as an sql clause
 // It satisfies the TableSQLClause interface
 func (c ColumnElem) String(dialect Dialect) string {
@@ -57,6 +64,9 @@ func (c ColumnElem) String(dialect Dialect) string {
 		}
 		if len(constraintNames) != 0 {
 			colSpec = fmt.Sprintf("%s %s", colSpec, strings.Join(constraintNames, " "))
+		}
+		if c.Options.InlinePrimaryKey {
+			colSpec += " PRIMARY KEY"
 		}
 	}
 	res := fmt.Sprintf("%s %s", dialect.Escape(c.Name), colSpec)

--- a/column_test.go
+++ b/column_test.go
@@ -29,7 +29,7 @@ func TestColumn(t *testing.T) {
 	precisionCol := Column("f", Type("FLOAT").Precision(2, 5)).Null()
 	assert.Equal(t, "f FLOAT(2, 5) NULL", precisionCol.String(sqlite))
 
-	col = Column("id", Int()).PrimaryKey().AutoIncrement()
+	col = Column("id", Int()).PrimaryKey().AutoIncrement().inlinePrimaryKey()
 
 	assert.Equal(t, "id INTEGER PRIMARY KEY", col.String(sqlite))
 	assert.Equal(t, "`id` INT PRIMARY KEY AUTO_INCREMENT", col.String(mysql))

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -63,7 +63,7 @@ func (d *MysqlDialect) Placeholders(values ...interface{}) []string {
 // AutoIncrement generates auto increment sql of current dialect
 func (d *MysqlDialect) AutoIncrement(column *ColumnElem) string {
 	colSpec := d.CompileType(column.Type)
-	if column.Options.PrimaryKey {
+	if column.Options.InlinePrimaryKey {
 		colSpec += " PRIMARY KEY"
 	}
 	colSpec += " AUTO_INCREMENT"

--- a/dialect_postgres.go
+++ b/dialect_postgres.go
@@ -72,7 +72,7 @@ func (d *PostgresDialect) AutoIncrement(column *ColumnElem) string {
 	} else {
 		colSpec = "SERIAL"
 	}
-	if column.Options.PrimaryKey {
+	if column.Options.InlinePrimaryKey {
 		colSpec += " PRIMARY KEY"
 	}
 	return colSpec

--- a/dialect_sqlite.go
+++ b/dialect_sqlite.go
@@ -59,7 +59,10 @@ func (d *SqliteDialect) Placeholders(values ...interface{}) []string {
 }
 
 // AutoIncrement generates auto increment sql of current dialect
-func (d *SqliteDialect) AutoIncrement(colum *ColumnElem) string {
+func (d *SqliteDialect) AutoIncrement(column *ColumnElem) string {
+	if !column.Options.InlinePrimaryKey {
+		panic("Sqlite does not support non-primarykey autoincrement columns")
+	}
 	return "INTEGER PRIMARY KEY"
 }
 

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -152,6 +152,13 @@ func (suite *SqliteTestSuite) TestSqlite() {
 	assert.Nil(suite.T(), suite.metadata.DropAll(suite.engine))
 }
 
+func (suite *SqliteTestSuite) TestSqliteAutoIncrement() {
+	col := Column("test", Int()).AutoIncrement()
+	assert.Panics(suite.T(), func() {
+		col.String(suite.engine.Dialect())
+	})
+}
+
 func TestSqliteTestSuite(t *testing.T) {
 	suite.Run(t, new(SqliteTestSuite))
 }

--- a/table_test.go
+++ b/table_test.go
@@ -42,9 +42,8 @@ func (suite *TableTestSuite) TestTablePrimaryForeignKey() {
 	assert.Contains(suite.T(), ddl, "CREATE TABLE users (")
 	assert.Contains(suite.T(), ddl, "auth_token VARCHAR(40)")
 	assert.Contains(suite.T(), ddl, "role_id VARCHAR(40)")
-	assert.Contains(suite.T(), ddl, "id VARCHAR(40)")
+	assert.Contains(suite.T(), ddl, "id VARCHAR(40) PRIMARY KEY")
 	assert.Contains(suite.T(), ddl, "session_id VARCHAR(40)")
-	assert.Contains(suite.T(), ddl, "PRIMARY KEY(id)")
 	assert.Contains(suite.T(), ddl, "FOREIGN KEY(session_id, auth_token) REFERENCES sessions(id, auth_token)")
 	assert.Contains(suite.T(), ddl, "FOREIGN KEY(role_id) REFERENCES roles(id)")
 	assert.Contains(suite.T(), ddl, ");")
@@ -55,7 +54,7 @@ func (suite *TableTestSuite) TestTablePrimaryKey() {
 		"users",
 		Column("id", Varchar().Size(40)).PrimaryKey(),
 	)
-	assert.Empty(suite.T(), t.PrimaryKeyConstraint.Columns)
+	assert.Equal(suite.T(), []string{"id"}, t.PrimaryKeyConstraint.Columns)
 
 	t = Table(
 		"users",
@@ -64,6 +63,9 @@ func (suite *TableTestSuite) TestTablePrimaryKey() {
 	)
 
 	assert.Equal(suite.T(), []string{"fname", "lname"}, t.PrimaryKeyConstraint.Columns)
+
+	ddl := t.Create(NewDialect("mysql"))
+	assert.Contains(suite.T(), ddl, "PRIMARY KEY(fname, lname)")
 
 	assert.Panics(suite.T(), func() {
 		Table(


### PR DESCRIPTION
The single column primary keys were not created at all.

Added the 'InlinePrimaryKey' option on columns so they can render the
'PRIMARY KEY' inlined when decided by the Table() constructor.