### PR TITLE
Where() now takes a ...Clause

### DIFF
--- a/select.go
+++ b/select.go
@@ -46,8 +46,8 @@ func (s SelectStmt) From(selectable Selectable) SelectStmt {
 }
 
 // Where sets the where clause of select statement
-func (s SelectStmt) Where(clause Clause) SelectStmt {
-	where := Where(clause)
+func (s SelectStmt) Where(clauses ...Clause) SelectStmt {
+	where := Where(clauses...)
 	s.where = &where
 	return s
 }

--- a/where.go
+++ b/where.go
@@ -1,7 +1,13 @@
 package qb
 
 // Where generates a compilable where clause
-func Where(clause Clause) WhereClause {
+func Where(clauses ...Clause) WhereClause {
+	var clause Clause
+	if len(clauses) == 1 {
+		clause = clauses[0]
+	} else {
+		clause = And(clauses...)
+	}
 	return WhereClause{clause}
 }
 

--- a/where_test.go
+++ b/where_test.go
@@ -1,0 +1,16 @@
+package qb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWhere(t *testing.T) {
+	assert.Equal(t,
+		"WHERE X", asDefSQL(
+			Where(SQLText("X"))))
+	assert.Equal(t,
+		"WHERE (X AND Y)", asDefSQL(
+			Where(SQLText("X"), SQLText("Y"))))
+}


### PR DESCRIPTION
While keeping compatibility, it makes it easier to build where clauses
with a single top-level And()