### PR TITLE
Publish select fields

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -280,8 +280,8 @@ func (c SQLCompiler) VisitSelect(context *CompilerContext, selectStmt SelectStmt
 		addLine(sql)
 	}
 
-	if (selectStmt.offset != nil) && (selectStmt.count != nil) {
-		addLine(fmt.Sprintf("LIMIT %d OFFSET %d", *selectStmt.count, *selectStmt.offset))
+	if (selectStmt.OffsetValue != nil) && (selectStmt.LimitValue != nil) {
+		addLine(fmt.Sprintf("LIMIT %d OFFSET %d", *selectStmt.LimitValue, *selectStmt.OffsetValue))
 	}
 
 	return strings.Join(lines, "\n")

--- a/compiler.go
+++ b/compiler.go
@@ -243,7 +243,7 @@ func (c SQLCompiler) VisitSelect(context *CompilerContext, selectStmt SelectStmt
 
 	// select
 	columns := []string{}
-	for _, c := range selectStmt.sel {
+	for _, c := range selectStmt.SelectList {
 		sql := c.Accept(context)
 		columns = append(columns, sql)
 	}

--- a/compiler.go
+++ b/compiler.go
@@ -261,7 +261,7 @@ func (c SQLCompiler) VisitSelect(context *CompilerContext, selectStmt SelectStmt
 
 	// group by
 	groupByCols := []string{}
-	for _, c := range selectStmt.groupBy {
+	for _, c := range selectStmt.GroupByClause {
 		groupByCols = append(groupByCols, context.Dialect.Escape(c.Name))
 	}
 	if len(groupByCols) > 0 {

--- a/compiler.go
+++ b/compiler.go
@@ -222,13 +222,13 @@ func (c SQLCompiler) VisitList(context *CompilerContext, list ListClause) string
 }
 
 // VisitOrderBy compiles a ORDER BY sql clause
-func (c SQLCompiler) VisitOrderBy(context *CompilerContext, orderBy OrderByClause) string {
+func (c SQLCompiler) VisitOrderBy(context *CompilerContext, OrderByClause OrderByClause) string {
 	cols := []string{}
-	for _, c := range orderBy.columns {
+	for _, c := range OrderByClause.columns {
 		cols = append(cols, c.Accept(context))
 	}
 
-	return fmt.Sprintf("ORDER BY %s %s", strings.Join(cols, ", "), orderBy.t)
+	return fmt.Sprintf("ORDER BY %s %s", strings.Join(cols, ", "), OrderByClause.t)
 }
 
 // VisitSelect compiles a SELECT statement
@@ -275,8 +275,8 @@ func (c SQLCompiler) VisitSelect(context *CompilerContext, selectStmt SelectStmt
 	}
 
 	// order by
-	if selectStmt.orderBy != nil {
-		sql := selectStmt.orderBy.Accept(context)
+	if selectStmt.OrderByClause != nil {
+		sql := selectStmt.OrderByClause.Accept(context)
 		addLine(sql)
 	}
 

--- a/compiler.go
+++ b/compiler.go
@@ -255,8 +255,8 @@ func (c SQLCompiler) VisitSelect(context *CompilerContext, selectStmt SelectStmt
 	}
 
 	// where
-	if selectStmt.where != nil {
-		addLine(selectStmt.where.Accept(context))
+	if selectStmt.WhereClause != nil {
+		addLine(selectStmt.WhereClause.Accept(context))
 	}
 
 	// group by

--- a/compiler.go
+++ b/compiler.go
@@ -269,7 +269,7 @@ func (c SQLCompiler) VisitSelect(context *CompilerContext, selectStmt SelectStmt
 	}
 
 	// having
-	for _, h := range selectStmt.having {
+	for _, h := range selectStmt.HavingClause {
 		sql := h.Accept(context)
 		addLine(sql)
 	}

--- a/compiler.go
+++ b/compiler.go
@@ -237,8 +237,8 @@ func (c SQLCompiler) VisitSelect(context *CompilerContext, selectStmt SelectStmt
 	addLine := func(s string) {
 		lines = append(lines, s)
 	}
-	if !context.InSubQuery && selectStmt.from != nil {
-		context.DefaultTableName = selectStmt.from.DefaultName()
+	if !context.InSubQuery && selectStmt.FromClause != nil {
+		context.DefaultTableName = selectStmt.FromClause.DefaultName()
 	}
 
 	// select
@@ -250,8 +250,8 @@ func (c SQLCompiler) VisitSelect(context *CompilerContext, selectStmt SelectStmt
 	addLine(fmt.Sprintf("SELECT %s", strings.Join(columns, ", ")))
 
 	// from
-	if selectStmt.from != nil {
-		addLine(fmt.Sprintf("FROM %s", selectStmt.from.Accept(context)))
+	if selectStmt.FromClause != nil {
+		addLine(fmt.Sprintf("FROM %s", selectStmt.FromClause.Accept(context)))
 	}
 
 	// where

--- a/select.go
+++ b/select.go
@@ -15,22 +15,22 @@ type Selectable interface {
 // Select generates a select statement and returns it
 func Select(clauses ...Clause) SelectStmt {
 	return SelectStmt{
-		SelectList: clauses,
-		groupBy:    []ColumnElem{},
-		having:     []HavingClause{},
+		SelectList:    clauses,
+		GroupByClause: []ColumnElem{},
+		having:        []HavingClause{},
 	}
 }
 
 // SelectStmt is the base struct for building select statements
 type SelectStmt struct {
-	SelectList  []Clause
-	FromClause  Selectable
-	groupBy     []ColumnElem
-	orderBy     *OrderByClause
-	having      []HavingClause
-	WhereClause *WhereClause
-	offset      *int
-	count       *int
+	SelectList    []Clause
+	FromClause    Selectable
+	GroupByClause []ColumnElem
+	orderBy       *OrderByClause
+	having        []HavingClause
+	WhereClause   *WhereClause
+	offset        *int
+	count         *int
 }
 
 // Select sets the selected columns
@@ -96,7 +96,7 @@ func (s SelectStmt) Desc() SelectStmt {
 
 // GroupBy appends columns to group by clause of the select statement
 func (s SelectStmt) GroupBy(cols ...ColumnElem) SelectStmt {
-	s.groupBy = append(s.groupBy, cols...)
+	s.GroupByClause = append(s.GroupByClause, cols...)
 	return s
 }
 

--- a/select.go
+++ b/select.go
@@ -26,7 +26,7 @@ type SelectStmt struct {
 	SelectList    []Clause
 	FromClause    Selectable
 	GroupByClause []ColumnElem
-	orderBy       *OrderByClause
+	OrderByClause *OrderByClause
 	having        []HavingClause
 	WhereClause   *WhereClause
 	offset        *int
@@ -76,21 +76,21 @@ func (s SelectStmt) RightJoin(right Selectable, onClause ...Clause) SelectStmt {
 // OrderBy(usersTable.C("id")).Asc()
 // OrderBy(usersTable.C("email")).Desc()
 func (s SelectStmt) OrderBy(columns ...ColumnElem) SelectStmt {
-	s.orderBy = &OrderByClause{columns, "ASC"}
+	s.OrderByClause = &OrderByClause{columns, "ASC"}
 	return s
 }
 
 // Asc sets the t type of current order by clause
 // NOTE: Please use it after calling OrderBy()
 func (s SelectStmt) Asc() SelectStmt {
-	s.orderBy.t = "ASC"
+	s.OrderByClause.t = "ASC"
 	return s
 }
 
 // Desc sets the t type of current order by clause
 // NOTE: Please use it after calling OrderBy()
 func (s SelectStmt) Desc() SelectStmt {
-	s.orderBy.t = "DESC"
+	s.OrderByClause.t = "DESC"
 	return s
 }
 

--- a/select.go
+++ b/select.go
@@ -23,14 +23,14 @@ func Select(clauses ...Clause) SelectStmt {
 
 // SelectStmt is the base struct for building select statements
 type SelectStmt struct {
-	sel     []Clause
-	from    Selectable
-	groupBy []ColumnElem
-	orderBy *OrderByClause
-	having  []HavingClause
-	where   *WhereClause
-	offset  *int
-	count   *int
+	sel         []Clause
+	from        Selectable
+	groupBy     []ColumnElem
+	orderBy     *OrderByClause
+	having      []HavingClause
+	WhereClause *WhereClause
+	offset      *int
+	count       *int
 }
 
 // Select sets the selected columns
@@ -48,7 +48,7 @@ func (s SelectStmt) From(selectable Selectable) SelectStmt {
 // Where sets the where clause of select statement
 func (s SelectStmt) Where(clauses ...Clause) SelectStmt {
 	where := Where(clauses...)
-	s.where = &where
+	s.WhereClause = &where
 	return s
 }
 

--- a/select.go
+++ b/select.go
@@ -17,7 +17,7 @@ func Select(clauses ...Clause) SelectStmt {
 	return SelectStmt{
 		SelectList:    clauses,
 		GroupByClause: []ColumnElem{},
-		having:        []HavingClause{},
+		HavingClause:  []HavingClause{},
 	}
 }
 
@@ -27,7 +27,7 @@ type SelectStmt struct {
 	FromClause    Selectable
 	GroupByClause []ColumnElem
 	OrderByClause *OrderByClause
-	having        []HavingClause
+	HavingClause  []HavingClause
 	WhereClause   *WhereClause
 	offset        *int
 	count         *int
@@ -102,7 +102,7 @@ func (s SelectStmt) GroupBy(cols ...ColumnElem) SelectStmt {
 
 // Having appends a having clause to select statement
 func (s SelectStmt) Having(aggregate AggregateClause, op string, value interface{}) SelectStmt {
-	s.having = append(s.having, HavingClause{aggregate, op, value})
+	s.HavingClause = append(s.HavingClause, HavingClause{aggregate, op, value})
 	return s
 }
 

--- a/select.go
+++ b/select.go
@@ -29,8 +29,8 @@ type SelectStmt struct {
 	OrderByClause *OrderByClause
 	HavingClause  []HavingClause
 	WhereClause   *WhereClause
-	offset        *int
-	count         *int
+	OffsetValue   *int
+	LimitValue    *int
 }
 
 // Select sets the selected columns
@@ -107,9 +107,9 @@ func (s SelectStmt) Having(aggregate AggregateClause, op string, value interface
 }
 
 // Limit sets the offset & count values of the select statement
-func (s SelectStmt) Limit(offset int, count int) SelectStmt {
-	s.offset = &offset
-	s.count = &count
+func (s SelectStmt) Limit(offset int, limit int) SelectStmt {
+	s.OffsetValue = &offset
+	s.LimitValue = &limit
 	return s
 }
 

--- a/select.go
+++ b/select.go
@@ -24,7 +24,7 @@ func Select(clauses ...Clause) SelectStmt {
 // SelectStmt is the base struct for building select statements
 type SelectStmt struct {
 	SelectList  []Clause
-	from        Selectable
+	FromClause  Selectable
 	groupBy     []ColumnElem
 	orderBy     *OrderByClause
 	having      []HavingClause
@@ -41,7 +41,7 @@ func (s SelectStmt) Select(clauses ...Clause) SelectStmt {
 
 // From sets the from selectable of select statement
 func (s SelectStmt) From(selectable Selectable) SelectStmt {
-	s.from = selectable
+	s.FromClause = selectable
 	return s
 }
 
@@ -54,22 +54,22 @@ func (s SelectStmt) Where(clauses ...Clause) SelectStmt {
 
 // InnerJoin appends an inner join clause to the select statement
 func (s SelectStmt) InnerJoin(right Selectable, onClause ...Clause) SelectStmt {
-	return s.From(Join("INNER JOIN", s.from, right, onClause...))
+	return s.From(Join("INNER JOIN", s.FromClause, right, onClause...))
 }
 
 // CrossJoin appends an cross join clause to the select statement
 func (s SelectStmt) CrossJoin(right Selectable) SelectStmt {
-	return s.From(Join("CROSS JOIN", s.from, right, nil))
+	return s.From(Join("CROSS JOIN", s.FromClause, right, nil))
 }
 
 // LeftJoin appends an left outer join clause to the select statement
 func (s SelectStmt) LeftJoin(right Selectable, onClause ...Clause) SelectStmt {
-	return s.From(Join("LEFT OUTER JOIN", s.from, right, onClause...))
+	return s.From(Join("LEFT OUTER JOIN", s.FromClause, right, onClause...))
 }
 
 // RightJoin appends a right outer join clause to select statement
 func (s SelectStmt) RightJoin(right Selectable, onClause ...Clause) SelectStmt {
-	return s.From(Join("RIGHT OUTER JOIN", s.from, right, onClause...))
+	return s.From(Join("RIGHT OUTER JOIN", s.FromClause, right, onClause...))
 }
 
 // OrderBy generates an OrderByClause and sets select statement's orderbyclause

--- a/select.go
+++ b/select.go
@@ -15,15 +15,15 @@ type Selectable interface {
 // Select generates a select statement and returns it
 func Select(clauses ...Clause) SelectStmt {
 	return SelectStmt{
-		sel:     clauses,
-		groupBy: []ColumnElem{},
-		having:  []HavingClause{},
+		SelectList: clauses,
+		groupBy:    []ColumnElem{},
+		having:     []HavingClause{},
 	}
 }
 
 // SelectStmt is the base struct for building select statements
 type SelectStmt struct {
-	sel         []Clause
+	SelectList  []Clause
 	from        Selectable
 	groupBy     []ColumnElem
 	orderBy     *OrderByClause
@@ -35,7 +35,7 @@ type SelectStmt struct {
 
 // Select sets the selected columns
 func (s SelectStmt) Select(clauses ...Clause) SelectStmt {
-	s.sel = clauses
+	s.SelectList = clauses
 	return s
 }
 

--- a/select_test.go
+++ b/select_test.go
@@ -147,10 +147,10 @@ func (suite *SelectTestSuite) TestJoin() {
 		InnerJoin(suite.users, suite.sessions.C("user_id"), suite.users.C("id")).
 		Where(Eq(suite.sessions.C("user_id"), 5))
 
-	assert.Equal(suite.T(), suite.sessions.C("user_id"), selInnerJoin.from.C("user_id"))
-	assert.Panics(suite.T(), func() { selInnerJoin.from.C("invalid") })
+	assert.Equal(suite.T(), suite.sessions.C("user_id"), selInnerJoin.FromClause.C("user_id"))
+	assert.Panics(suite.T(), func() { selInnerJoin.FromClause.C("invalid") })
 
-	assert.Equal(suite.T(), len(suite.sessions.All())+len(suite.users.All()), len(selInnerJoin.from.All()))
+	assert.Equal(suite.T(), len(suite.sessions.All())+len(suite.users.All()), len(selInnerJoin.FromClause.All()))
 
 	var statement *Stmt
 


### PR DESCRIPTION
Select fields need to be accessible for 2 reasons:
- The dialects defined in different packages will have to read them
- The end-user may need to modify directly a clause, in case the clause is not constructed all at once

The new names for the fields (SelectList in particular) where chosen to be consistent with the SQL BNF grammar (see http://savage.net.au/SQL/sql-99.bnf.html).

This PR breaks no API