### PR TITLE
Sqlite escaping

### DIFF
--- a/column_test.go
+++ b/column_test.go
@@ -19,23 +19,23 @@ func TestColumn(t *testing.T) {
 	assert.Equal(t, "id", col.Name)
 	assert.Equal(t, Varchar().Size(40), col.Type)
 
-	assert.Equal(t, "id VARCHAR(40)", col.String(sqlite))
+	assert.Equal(t, "\"id\" VARCHAR(40)", col.String(sqlite))
 	assert.Equal(t, "`id` VARCHAR(40)", col.String(mysql))
 	assert.Equal(t, "\"id\" VARCHAR(40)", col.String(postgres))
 
 	col = Column("s", Varchar().Size(255)).Unique().NotNull().Default("hello")
-	assert.Equal(t, "s VARCHAR(255) UNIQUE NOT NULL DEFAULT 'hello'", col.String(sqlite))
+	assert.Equal(t, "\"s\" VARCHAR(255) UNIQUE NOT NULL DEFAULT 'hello'", col.String(sqlite))
 
 	precisionCol := Column("f", Type("FLOAT").Precision(2, 5)).Null()
-	assert.Equal(t, "f FLOAT(2, 5) NULL", precisionCol.String(sqlite))
+	assert.Equal(t, "\"f\" FLOAT(2, 5) NULL", precisionCol.String(sqlite))
 
 	col = Column("id", Int()).PrimaryKey().AutoIncrement().inlinePrimaryKey()
 
-	assert.Equal(t, "id INTEGER PRIMARY KEY", col.String(sqlite))
+	assert.Equal(t, "\"id\" INTEGER PRIMARY KEY", col.String(sqlite))
 	assert.Equal(t, "`id` INT PRIMARY KEY AUTO_INCREMENT", col.String(mysql))
 	assert.Equal(t, "\"id\" SERIAL PRIMARY KEY", col.String(postgres))
 
-	assert.Equal(t, "c INT TEST", Column("c", Int()).Constraint("TEST").String(sqlite))
+	assert.Equal(t, "\"c\" INT TEST", Column("c", Int()).Constraint("TEST").String(sqlite))
 
 	// like
 	like := col.Like("s%")
@@ -43,7 +43,7 @@ func TestColumn(t *testing.T) {
 	likeMysql, likeBindingsMysql := asSQLBinds(like, mysql)
 	likePostgres, likeBindingsPostgres := asSQLBinds(like, postgres)
 
-	assert.Equal(t, "id LIKE ?", likeSqlite)
+	assert.Equal(t, "\"id\" LIKE ?", likeSqlite)
 	assert.Equal(t, []interface{}{"s%"}, likeBindingsSqlite)
 	assert.Equal(t, "`id` LIKE ?", likeMysql)
 	assert.Equal(t, []interface{}{"s%"}, likeBindingsMysql)
@@ -56,7 +56,7 @@ func TestColumn(t *testing.T) {
 	notInMysql, likeBindingsMysql := asSQLBinds(notIn, mysql)
 	notInPostgres, likeBindingsPostgres := asSQLBinds(notIn, postgres)
 
-	assert.Equal(t, "id NOT IN (?, ?)", notInSqlite)
+	assert.Equal(t, "\"id\" NOT IN (?, ?)", notInSqlite)
 	assert.Equal(t, []interface{}{"id1", "id2"}, likeBindingsSqlite)
 	assert.Equal(t, "`id` NOT IN (?, ?)", notInMysql)
 	assert.Equal(t, []interface{}{"id1", "id2"}, likeBindingsMysql)
@@ -69,7 +69,7 @@ func TestColumn(t *testing.T) {
 	inMysql, likeBindingsMysql := asSQLBinds(in, mysql)
 	inPostgres, likeBindingsPostgres := asSQLBinds(in, postgres)
 
-	assert.Equal(t, "id IN (?, ?)", inSqlite)
+	assert.Equal(t, "\"id\" IN (?, ?)", inSqlite)
 	assert.Equal(t, []interface{}{"id1", "id2"}, likeBindingsSqlite)
 	assert.Equal(t, "`id` IN (?, ?)", inMysql)
 	assert.Equal(t, []interface{}{"id1", "id2"}, likeBindingsMysql)
@@ -82,7 +82,7 @@ func TestColumn(t *testing.T) {
 	notEqMysql, likeBindingsMysql := asSQLBinds(notEq, mysql)
 	notEqPostgres, likeBindingsPostgres := asSQLBinds(notEq, postgres)
 
-	assert.Equal(t, "id != ?", notEqSqlite)
+	assert.Equal(t, "\"id\" != ?", notEqSqlite)
 	assert.Equal(t, []interface{}{"id1"}, likeBindingsSqlite)
 	assert.Equal(t, "`id` != ?", notEqMysql)
 	assert.Equal(t, []interface{}{"id1"}, likeBindingsMysql)
@@ -95,7 +95,7 @@ func TestColumn(t *testing.T) {
 	eqMysql, likeBindingsMysql := asSQLBinds(eq, mysql)
 	eqPostgres, likeBindingsPostgres := asSQLBinds(eq, postgres)
 
-	assert.Equal(t, "id = ?", eqSqlite)
+	assert.Equal(t, "\"id\" = ?", eqSqlite)
 	assert.Equal(t, []interface{}{"id1"}, likeBindingsSqlite)
 	assert.Equal(t, "`id` = ?", eqMysql)
 	assert.Equal(t, []interface{}{"id1"}, likeBindingsMysql)
@@ -108,7 +108,7 @@ func TestColumn(t *testing.T) {
 	gtMysql, likeBindingsMysql := asSQLBinds(gt, mysql)
 	gtPostgres, likeBindingsPostgres := asSQLBinds(gt, postgres)
 
-	assert.Equal(t, "id > ?", gtSqlite)
+	assert.Equal(t, "\"id\" > ?", gtSqlite)
 	assert.Equal(t, []interface{}{"id1"}, likeBindingsSqlite)
 	assert.Equal(t, "`id` > ?", gtMysql)
 	assert.Equal(t, []interface{}{"id1"}, likeBindingsMysql)
@@ -121,7 +121,7 @@ func TestColumn(t *testing.T) {
 	ltMysql, likeBindingsMysql := asSQLBinds(lt, mysql)
 	ltPostgres, likeBindingsPostgres := asSQLBinds(lt, postgres)
 
-	assert.Equal(t, "id < ?", ltSqlite)
+	assert.Equal(t, "\"id\" < ?", ltSqlite)
 	assert.Equal(t, []interface{}{"id1"}, likeBindingsSqlite)
 	assert.Equal(t, "`id` < ?", ltMysql)
 	assert.Equal(t, []interface{}{"id1"}, likeBindingsMysql)
@@ -134,7 +134,7 @@ func TestColumn(t *testing.T) {
 	gteMysql, likeBindingsMysql := asSQLBinds(gte, mysql)
 	gtePostgres, likeBindingsPostgres := asSQLBinds(gte, postgres)
 
-	assert.Equal(t, "id >= ?", gteSqlite)
+	assert.Equal(t, "\"id\" >= ?", gteSqlite)
 	assert.Equal(t, []interface{}{"id1"}, likeBindingsSqlite)
 	assert.Equal(t, "`id` >= ?", gteMysql)
 	assert.Equal(t, []interface{}{"id1"}, likeBindingsMysql)
@@ -147,7 +147,7 @@ func TestColumn(t *testing.T) {
 	lteMysql, likeBindingsMysql := asSQLBinds(lte, mysql)
 	ltePostgres, likeBindingsPostgres := asSQLBinds(lte, postgres)
 
-	assert.Equal(t, "id <= ?", lteSqlite)
+	assert.Equal(t, "\"id\" <= ?", lteSqlite)
 	assert.Equal(t, []interface{}{"id1"}, likeBindingsSqlite)
 	assert.Equal(t, "`id` <= ?", lteMysql)
 	assert.Equal(t, []interface{}{"id1"}, likeBindingsMysql)
@@ -157,7 +157,7 @@ func TestColumn(t *testing.T) {
 	var sql string
 
 	sql = col.Accept(NewCompilerContext(sqlite))
-	assert.Equal(t, "id", sql)
+	assert.Equal(t, "\"id\"", sql)
 
 	sql = col.Accept(NewCompilerContext(mysql))
 	assert.Equal(t, "`id`", sql)

--- a/combiner_test.go
+++ b/combiner_test.go
@@ -25,7 +25,7 @@ func TestCombiners(t *testing.T) {
 	ctx := NewCompilerContext(sqlite)
 	sql = and.Accept(ctx)
 
-	assert.Equal(t, "(email = ? AND id != ?)", sql)
+	assert.Equal(t, "(\"email\" = ? AND \"id\" != ?)", sql)
 	assert.Equal(t, []interface{}{"al@pacino.com", 1}, ctx.Binds)
 
 	ctx = NewCompilerContext(mysql)
@@ -43,7 +43,7 @@ func TestCombiners(t *testing.T) {
 	ctx = NewCompilerContext(sqlite)
 	sql = or.Accept(ctx)
 
-	assert.Equal(t, "(email = ? OR id != ?)", sql)
+	assert.Equal(t, "(\"email\" = ? OR \"id\" != ?)", sql)
 	assert.Equal(t, []interface{}{"al@pacino.com", 1}, ctx.Binds)
 
 	ctx = NewCompilerContext(mysql)

--- a/conditional_test.go
+++ b/conditional_test.go
@@ -29,7 +29,7 @@ func TestConditionals(t *testing.T) {
 	like := Like(country, "%land%")
 
 	sql, bindings = compile(like, sqlite)
-	assert.Equal(t, "country LIKE ?", sql)
+	assert.Equal(t, "\"country\" LIKE ?", sql)
 	assert.Equal(t, []interface{}{"%land%"}, bindings)
 
 	sql, _ = compile(like, mysql)
@@ -43,7 +43,7 @@ func TestConditionals(t *testing.T) {
 	notIn := NotIn(country, "USA", "England", "Sweden")
 
 	sql, bindings = compile(notIn, sqlite)
-	assert.Equal(t, "country NOT IN (?, ?, ?)", sql)
+	assert.Equal(t, "\"country\" NOT IN (?, ?, ?)", sql)
 	assert.Equal(t, []interface{}{"USA", "England", "Sweden"}, bindings)
 
 	sql, bindings = compile(notIn, mysql)
@@ -57,7 +57,7 @@ func TestConditionals(t *testing.T) {
 	in := In(country, "USA", "England", "Sweden")
 
 	sql, bindings = compile(in, sqlite)
-	assert.Equal(t, "country IN (?, ?, ?)", sql)
+	assert.Equal(t, "\"country\" IN (?, ?, ?)", sql)
 	assert.Equal(t, []interface{}{"USA", "England", "Sweden"}, bindings)
 
 	sql, bindings = compile(in, mysql)
@@ -71,7 +71,7 @@ func TestConditionals(t *testing.T) {
 	notEq := NotEq(country, "USA")
 
 	sql, bindings = compile(notEq, sqlite)
-	assert.Equal(t, "country != ?", sql)
+	assert.Equal(t, "\"country\" != ?", sql)
 	assert.Equal(t, []interface{}{"USA"}, bindings)
 
 	sql, bindings = compile(notEq, mysql)
@@ -85,7 +85,7 @@ func TestConditionals(t *testing.T) {
 	eq := Eq(country, "Turkey")
 
 	sql, bindings = compile(eq, sqlite)
-	assert.Equal(t, "country = ?", sql)
+	assert.Equal(t, "\"country\" = ?", sql)
 	assert.Equal(t, []interface{}{"Turkey"}, bindings)
 
 	sql, bindings = compile(eq, mysql)
@@ -101,7 +101,7 @@ func TestConditionals(t *testing.T) {
 	gt := Gt(score, 1500)
 
 	sql, bindings = compile(gt, sqlite)
-	assert.Equal(t, "score > ?", sql)
+	assert.Equal(t, "\"score\" > ?", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
 	sql, bindings = compile(gt, mysql)
@@ -115,7 +115,7 @@ func TestConditionals(t *testing.T) {
 	lt := Lt(score, 1500)
 
 	sql, bindings = compile(lt, sqlite)
-	assert.Equal(t, "score < ?", sql)
+	assert.Equal(t, "\"score\" < ?", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
 	sql, bindings = compile(lt, mysql)
@@ -130,7 +130,7 @@ func TestConditionals(t *testing.T) {
 	gte := Gte(score, 1500)
 
 	sql, bindings = compile(gte, sqlite)
-	assert.Equal(t, "score >= ?", sql)
+	assert.Equal(t, "\"score\" >= ?", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
 	sql, bindings = compile(gte, mysql)
@@ -144,7 +144,7 @@ func TestConditionals(t *testing.T) {
 	lte := Lte(score, 1500)
 
 	sql, bindings = compile(lte, sqlite)
-	assert.Equal(t, "score <= ?", sql)
+	assert.Equal(t, "\"score\" <= ?", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
 	sql, bindings = compile(lte, mysql)

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -23,14 +23,14 @@ func TestConstraints(t *testing.T) {
 	postgres := NewDialect("postgres")
 	postgres.SetEscaping(true)
 
-	assert.Equal(t, "PRIMARY KEY(id)", PrimaryKey("id").String(sqlite))
+	assert.Equal(t, "PRIMARY KEY(\"id\")", PrimaryKey("id").String(sqlite))
 	assert.Equal(t, "PRIMARY KEY(`id`, `email`)", PrimaryKey("id", "email").String(mysql))
 	assert.Equal(t, "PRIMARY KEY(\"id\", \"email\")", PrimaryKey("id", "email").String(postgres))
 
-	assert.Contains(t, ForeignKey("user_id").References("users", "id").String(sqlite), "FOREIGN KEY(user_id) REFERENCES users(id)")
+	assert.Contains(t, ForeignKey("user_id").References("users", "id").String(sqlite), "FOREIGN KEY(\"user_id\") REFERENCES \"users\"(\"id\")")
 	assert.Contains(t, ForeignKey("user_id").References("users", "id").String(mysql), "FOREIGN KEY(`user_id`) REFERENCES `users`(`id`)")
 	assert.Contains(t, ForeignKey("user_id").References("users", "id").String(postgres), "FOREIGN KEY(\"user_id\") REFERENCES \"users\"(\"id\")")
-	assert.Contains(t, ForeignKey("user_id", "user_email").References("users", "id", "email").String(sqlite), "FOREIGN KEY(user_id, user_email) REFERENCES users(id, email)")
+	assert.Contains(t, ForeignKey("user_id", "user_email").References("users", "id", "email").String(sqlite), "FOREIGN KEY(\"user_id\", \"user_email\") REFERENCES \"users\"(\"id\", \"email\")")
 
 	assert.Panics(t, func() {
 		ForeignKey().OnUpdate("invalid")
@@ -39,16 +39,16 @@ func TestConstraints(t *testing.T) {
 		ForeignKey().OnDelete("invalid")
 	})
 	assert.Equal(t,
-		"\tFOREIGN KEY(user_id) REFERENCES users(id) ON DELETE SET NULL",
+		"\tFOREIGN KEY(\"user_id\") REFERENCES \"users\"(\"id\") ON DELETE SET NULL",
 		ForeignKey("user_id").References("users", "id").OnDelete("SET NULL").String(sqlite),
 	)
 	assert.Equal(t,
-		"\tFOREIGN KEY(user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE CASCADE",
+		"\tFOREIGN KEY(\"user_id\") REFERENCES \"users\"(\"id\") ON UPDATE CASCADE ON DELETE CASCADE",
 		ForeignKey("user_id").References("users", "id").OnUpdate("CASCADE").OnDelete("CASCADE").String(sqlite),
 	)
 
 	assert.Equal(t,
-		"CONSTRAINT u_users_id_email UNIQUE(id, email)",
+		"CONSTRAINT u_users_id_email UNIQUE(\"id\", \"email\")",
 		UniqueKey("id", "email").Table("users").String(sqlite))
 	assert.Equal(t,
 		"CONSTRAINT u_users_id_email UNIQUE(`id`, `email`)",

--- a/delete_test.go
+++ b/delete_test.go
@@ -27,7 +27,7 @@ func TestDelete(t *testing.T) {
 		Where(Eq(users.C("id"), 5)).
 		Build(sqlite)
 
-	assert.Equal(t, "DELETE FROM users\nWHERE users.id = ?;", statement.SQL())
+	assert.Equal(t, "DELETE FROM \"users\"\nWHERE \"users\".\"id\" = ?;", statement.SQL())
 	assert.Equal(t, []interface{}{5}, statement.Bindings())
 
 	statement = Delete(users).
@@ -46,5 +46,5 @@ func TestDelete(t *testing.T) {
 	assert.Equal(t, []interface{}{5}, statement.Bindings())
 
 	statement = Delete(users).Build(sqlite)
-	assert.Equal(t, "DELETE FROM users;", statement.SQL())
+	assert.Equal(t, "DELETE FROM \"users\";", statement.SQL())
 }

--- a/dialect_sqlite.go
+++ b/dialect_sqlite.go
@@ -30,6 +30,9 @@ func (d *SqliteDialect) CompileType(t TypeElem) string {
 
 // Escape wraps the string with escape characters of the dialect
 func (d *SqliteDialect) Escape(str string) string {
+	if d.escaping {
+		return fmt.Sprintf(`"%s"`, str)
+	}
 	return str
 }
 

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -76,8 +76,8 @@ func (suite *DialectTestSuite) TestSqliteDialect() {
 	assert.Equal(suite.T(), false, suite.sqlite.Escaping())
 	suite.sqlite.SetEscaping(true)
 	assert.Equal(suite.T(), true, suite.sqlite.Escaping())
-	assert.Equal(suite.T(), "test", suite.sqlite.Escape("test"))
-	assert.Equal(suite.T(), []string{"test"}, suite.sqlite.EscapeAll([]string{"test"}))
+	assert.Equal(suite.T(), "\"test\"", suite.sqlite.Escape("test"))
+	assert.Equal(suite.T(), []string{"\"test\""}, suite.sqlite.EscapeAll([]string{"test"}))
 	assert.Equal(suite.T(), "sqlite3", suite.sqlite.Driver())
 }
 

--- a/insert_test.go
+++ b/insert_test.go
@@ -29,7 +29,7 @@ func TestInsert(t *testing.T) {
 	})
 
 	statement = ins.Build(sqlite)
-	assert.Contains(t, statement.SQL(), "INSERT INTO users")
+	assert.Contains(t, statement.SQL(), "INSERT INTO \"users\"")
 	assert.Contains(t, statement.SQL(), "id", "email")
 	assert.Contains(t, statement.SQL(), "VALUES(?, ?)")
 	assert.Contains(t, statement.Bindings(), "9883cf81-3b56-4151-ae4e-3903c5bc436d")

--- a/select_test.go
+++ b/select_test.go
@@ -46,7 +46,7 @@ func (suite *SelectTestSuite) TestSimpleSelect() {
 
 	var statement *Stmt
 	statement = sel.Build(suite.sqlite)
-	assert.Equal(suite.T(), "SELECT id\nFROM users;", statement.SQL())
+	assert.Equal(suite.T(), "SELECT \"id\"\nFROM \"users\";", statement.SQL())
 
 	statement = sel.Build(suite.mysql)
 	assert.Equal(suite.T(), "SELECT `id`\nFROM `users`;", statement.SQL())
@@ -56,7 +56,7 @@ func (suite *SelectTestSuite) TestSimpleSelect() {
 
 	sel = sel.Select(Count(suite.users.C("id")))
 	statement = sel.Build(suite.sqlite)
-	assert.Equal(suite.T(), "SELECT COUNT(id)\nFROM users;", statement.SQL())
+	assert.Equal(suite.T(), "SELECT COUNT(\"id\")\nFROM \"users\";", statement.SQL())
 }
 
 func (suite *SelectTestSuite) TestSelectWhere() {
@@ -72,7 +72,7 @@ func (suite *SelectTestSuite) TestSelectWhere() {
 	var statement *Stmt
 
 	statement = sel.Build(suite.sqlite)
-	assert.Equal(suite.T(), "SELECT id\nFROM users\nWHERE (email = ? AND id != ?);", statement.SQL())
+	assert.Equal(suite.T(), "SELECT \"id\"\nFROM \"users\"\nWHERE (\"email\" = ? AND \"id\" != ?);", statement.SQL())
 	assert.Equal(suite.T(), []interface{}{"al@pacino.com", 5}, statement.Bindings())
 
 	statement = sel.Build(suite.mysql)
@@ -93,7 +93,7 @@ func (suite *SelectTestSuite) TestOrderByLimit() {
 
 	var statement *Stmt
 	statement = selOrderByDesc.Build(suite.sqlite)
-	assert.Equal(suite.T(), "SELECT id\nFROM sessions\nWHERE user_id = ?\nORDER BY id DESC\nLIMIT 20 OFFSET 0;", statement.SQL())
+	assert.Equal(suite.T(), "SELECT \"id\"\nFROM \"sessions\"\nWHERE \"user_id\" = ?\nORDER BY \"id\" DESC\nLIMIT 20 OFFSET 0;", statement.SQL())
 	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selOrderByDesc.Build(suite.mysql)
@@ -110,7 +110,7 @@ func (suite *SelectTestSuite) TestOrderByLimit() {
 		OrderBy(suite.sessions.C("id"))
 
 	statement = selWithoutOrder.Build(suite.sqlite)
-	assert.Equal(suite.T(), "SELECT id\nFROM sessions\nWHERE user_id = ?\nORDER BY id ASC;", statement.SQL())
+	assert.Equal(suite.T(), "SELECT \"id\"\nFROM \"sessions\"\nWHERE \"user_id\" = ?\nORDER BY \"id\" ASC;", statement.SQL())
 	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selWithoutOrder.Build(suite.mysql)
@@ -127,7 +127,7 @@ func (suite *SelectTestSuite) TestOrderByLimit() {
 		OrderBy(suite.sessions.C("id")).Asc()
 
 	statement = selOrderByAsc.Build(suite.sqlite)
-	assert.Equal(suite.T(), "SELECT id\nFROM sessions\nWHERE user_id = ?\nORDER BY id ASC;", statement.SQL())
+	assert.Equal(suite.T(), "SELECT \"id\"\nFROM \"sessions\"\nWHERE \"user_id\" = ?\nORDER BY \"id\" ASC;", statement.SQL())
 	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selOrderByAsc.Build(suite.mysql)
@@ -155,7 +155,7 @@ func (suite *SelectTestSuite) TestJoin() {
 	var statement *Stmt
 
 	statement = selInnerJoin.Build(suite.sqlite)
-	assert.Equal(suite.T(), "SELECT sessions.id, sessions.auth_token\nFROM sessions\nINNER JOIN users ON sessions.user_id = users.id\nWHERE sessions.user_id = ?;", statement.SQL())
+	assert.Equal(suite.T(), "SELECT \"sessions\".\"id\", \"sessions\".\"auth_token\"\nFROM \"sessions\"\nINNER JOIN \"users\" ON \"sessions\".\"user_id\" = \"users\".\"id\"\nWHERE \"sessions\".\"user_id\" = ?;", statement.SQL())
 	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selInnerJoin.Build(suite.mysql)
@@ -173,7 +173,7 @@ func (suite *SelectTestSuite) TestJoin() {
 		Where(Eq(suite.sessions.C("user_id"), 5))
 
 	statement = selLeftJoin.Build(suite.sqlite)
-	assert.Equal(suite.T(), "SELECT sessions.id, sessions.auth_token\nFROM sessions\nLEFT OUTER JOIN users ON sessions.user_id = users.id\nWHERE sessions.user_id = ?;", statement.SQL())
+	assert.Equal(suite.T(), "SELECT \"sessions\".\"id\", \"sessions\".\"auth_token\"\nFROM \"sessions\"\nLEFT OUTER JOIN \"users\" ON \"sessions\".\"user_id\" = \"users\".\"id\"\nWHERE \"sessions\".\"user_id\" = ?;", statement.SQL())
 	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selLeftJoin.Build(suite.mysql)
@@ -191,7 +191,7 @@ func (suite *SelectTestSuite) TestJoin() {
 		Where(Eq(suite.sessions.C("user_id"), 5))
 
 	statement = selRightJoin.Build(suite.sqlite)
-	assert.Equal(suite.T(), "SELECT sessions.id\nFROM sessions\nRIGHT OUTER JOIN users ON sessions.user_id = users.id\nWHERE sessions.user_id = ?;", statement.SQL())
+	assert.Equal(suite.T(), "SELECT \"sessions\".\"id\"\nFROM \"sessions\"\nRIGHT OUTER JOIN \"users\" ON \"sessions\".\"user_id\" = \"users\".\"id\"\nWHERE \"sessions\".\"user_id\" = ?;", statement.SQL())
 	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selRightJoin.Build(suite.mysql)
@@ -209,7 +209,7 @@ func (suite *SelectTestSuite) TestJoin() {
 		Where(Eq(suite.sessions.C("user_id"), 5))
 
 	statement = selCrossJoin.Build(suite.sqlite)
-	assert.Equal(suite.T(), "SELECT sessions.id\nFROM sessions\nCROSS JOIN users\nWHERE sessions.user_id = ?;", statement.SQL())
+	assert.Equal(suite.T(), "SELECT \"sessions\".\"id\"\nFROM \"sessions\"\nCROSS JOIN \"users\"\nWHERE \"sessions\".\"user_id\" = ?;", statement.SQL())
 	assert.Equal(suite.T(), []interface{}{5}, statement.Bindings())
 
 	statement = selCrossJoin.Build(suite.mysql)
@@ -229,7 +229,7 @@ func (suite *SelectTestSuite) TestGroupByHaving() {
 
 	var statement *Stmt
 	statement = sel.Build(suite.sqlite)
-	assert.Equal(suite.T(), "SELECT COUNT(id)\nFROM sessions\nGROUP BY user_id\nHAVING SUM(id) > ?;", statement.SQL())
+	assert.Equal(suite.T(), "SELECT COUNT(\"id\")\nFROM \"sessions\"\nGROUP BY \"user_id\"\nHAVING SUM(\"id\") > ?;", statement.SQL())
 	assert.Equal(suite.T(), []interface{}{4}, statement.Bindings())
 
 	statement = sel.Build(suite.mysql)
@@ -245,7 +245,7 @@ func (suite *SelectTestSuite) TestAlias() {
 	sessionA := Alias("newname", suite.sessions)
 	sel := Select(sessionA.C("id")).From(sessionA)
 	st := sel.Build(suite.sqlite)
-	assert.Equal(suite.T(), "SELECT id\nFROM sessions AS newname;", st.SQL())
+	assert.Equal(suite.T(), "SELECT \"id\"\nFROM \"sessions\" AS \"newname\";", st.SQL())
 
 	sel = Select(sessionA.All()...).From(sessionA)
 	sql := sel.Build(suite.mysql).SQL()

--- a/update_test.go
+++ b/update_test.go
@@ -28,7 +28,7 @@ func TestUpdate(t *testing.T) {
 		Values(map[string]interface{}{"email": "robert@de.niro"}).
 		Build(sqlite)
 
-	assert.Equal(t, "UPDATE users\nSET email = ?;", statement.SQL())
+	assert.Equal(t, "UPDATE \"users\"\nSET \"email\" = ?;", statement.SQL())
 	assert.Equal(t, []interface{}{"robert@de.niro"}, statement.Bindings())
 
 	statement = Update(users).

--- a/upsert_test.go
+++ b/upsert_test.go
@@ -41,7 +41,7 @@ func TestUpsert(t *testing.T) {
 	})
 
 	statement = ups.Build(sqlite)
-	assert.Contains(t, statement.SQL(), "REPLACE INTO users")
+	assert.Contains(t, statement.SQL(), `REPLACE INTO "users"`)
 	assert.Contains(t, statement.SQL(), "id", "email", "created_at")
 	assert.Contains(t, statement.SQL(), "VALUES(?, ?, ?)")
 	assert.Contains(t, statement.Bindings(), "9883cf81-3b56-4151-ae4e-3903c5bc436d")


### PR DESCRIPTION
Sqlite supports escaping keywords (see
http://www.sqlite.org/lang_keywords.html)