### PR TITLE
Make the default logger SetLogFlags actually work

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -56,6 +56,11 @@ func (e *Engine) SetLogger(logger Logger) {
 	e.logger = logger
 }
 
+// SetLogFlags sets the log flags on the current logger
+func (e *Engine) SetLogFlags(flags int) {
+	e.logger.SetLogFlags(flags)
+}
+
 func (e *Engine) log(statement *Stmt) {
 	logFlags := e.logger.LogFlags()
 	if logFlags == LQuery || logFlags == (LQuery|LBindings) {

--- a/engine.go
+++ b/engine.go
@@ -58,20 +58,17 @@ func (e *Engine) SetLogger(logger Logger) {
 }
 
 // SetLogFlags sets the log flags on the current logger
-func (e *Engine) SetLogFlags(flags int) {
+func (e *Engine) SetLogFlags(flags LogFlags) {
 	e.logger.SetLogFlags(flags)
 }
 
 func (e *Engine) log(statement *Stmt) {
 	logFlags := e.logger.LogFlags()
-	if logFlags == LQuery || logFlags == (LQuery|LBindings) {
-		e.logger.Println(statement.SQL())
+	if logFlags & LQuery != 0 {
+		e.logger.Println("SQL:", statement.SQL())
 	}
-	if logFlags == LBindings || logFlags == (LQuery|LBindings) {
-		e.logger.Println(statement.Bindings())
-	}
-	if logFlags != LDefault {
-		e.logger.Println()
+	if logFlags & LBindings != 0 {
+		e.logger.Println("Bindings:", statement.Bindings())
 	}
 }
 

--- a/engine.go
+++ b/engine.go
@@ -2,10 +2,11 @@ package qb
 
 import (
 	"database/sql"
-	"github.com/jmoiron/sqlx"
-	"github.com/serenize/snaker"
 	"log"
 	"os"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/serenize/snaker"
 )
 
 // New generates a new engine and returns it as an engine pointer
@@ -135,7 +136,7 @@ func (e *Engine) Dsn() string {
 	return e.dsn
 }
 
-// Begin begins a transaction and return a *yago.Tx
+// Begin begins a transaction and return a *qb.Tx
 func (e *Engine) Begin() (*Tx, error) {
 	tx, err := e.db.Beginx()
 	if err != nil {

--- a/logger.go
+++ b/logger.go
@@ -2,15 +2,19 @@ package qb
 
 import "log"
 
-// There are the log flags qb can use
-// The default log flag is not at all logging
+// These are the log flags qb can use
 const (
-	LDefault = iota
+	// LDefault is the default flag that logs nothing
+	LDefault LogFlags = 0
 	// LQuery Flag to log queries
-	LQuery
+	LQuery LogFlags = 1 << iota
 	// LBindings Flag to log bindings
 	LBindings
 )
+
+// LogFlags is the type we use for flags that can be passed
+// to the logger
+type LogFlags uint
 
 // Logger is the std logger interface of the qb engine
 type Logger interface {
@@ -26,23 +30,23 @@ type Logger interface {
 	Panicf(string, ...interface{})
 	Panicln(...interface{})
 
-	LogFlags() int
-	SetLogFlags(int)
+	LogFlags() LogFlags
+	SetLogFlags(LogFlags)
 }
 
 // DefaultLogger is the default logger of qb engine unless engine.SetLogger() is not called
 type DefaultLogger struct {
-	logFlags int
+	logFlags LogFlags
 	*log.Logger
 }
 
 // SetLogFlags sets the logflags
 // It is for changing engine log flags
-func (l *DefaultLogger) SetLogFlags(logFlags int) {
+func (l *DefaultLogger) SetLogFlags(logFlags LogFlags) {
 	l.logFlags = logFlags
 }
 
 // LogFlags gets the logflags as an int
-func (l *DefaultLogger) LogFlags() int {
+func (l *DefaultLogger) LogFlags() LogFlags {
 	return l.logFlags
 }

--- a/logger.go
+++ b/logger.go
@@ -38,11 +38,11 @@ type DefaultLogger struct {
 
 // SetLogFlags sets the logflags
 // It is for changing engine log flags
-func (l DefaultLogger) SetLogFlags(logFlags int) {
+func (l *DefaultLogger) SetLogFlags(logFlags int) {
 	l.logFlags = logFlags
 }
 
 // LogFlags gets the logflags as an int
-func (l DefaultLogger) LogFlags() int {
+func (l *DefaultLogger) LogFlags() int {
 	return l.logFlags
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -24,9 +24,21 @@ func TestLogger(t *testing.T) {
 	_, err = engine.Exec(actors.Insert().Values(map[string]interface{}{"id": 5}))
 	assert.Nil(t, err)
 
-	engine.Logger().SetLogFlags(LBindings)
+	engine.Logger().SetLogFlags(LQuery|LBindings)
 	_, err = engine.Exec(actors.Insert().Values(map[string]interface{}{"id": 10}))
 	assert.Nil(t, err)
 
 	assert.Equal(t, engine.Logger().LogFlags(), LQuery|LBindings)
+}
+
+func TestLoggerFlags(t *testing.T) {
+	engine, err := New("postgres", "user=root dbname=pqtest")
+	assert.Equal(t, nil, err)
+
+	// before setting flags, this is on the default
+	assert.Equal(t, engine.Logger().LogFlags(), LDefault)
+
+	engine.SetLogFlags(LBindings)
+	// after setting flags, we have the expected value
+	assert.Equal(t, engine.Logger().LogFlags(), LBindings)
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,9 +1,10 @@
 package qb
 
 import (
-	"github.com/stretchr/testify/assert"
 	"log"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLogger(t *testing.T) {


### PR DESCRIPTION
the method was not a pointer receiver and thus did not change the original logger but just its copy...