### PR TITLE
Add a new specific QbError that is returned by the sql functions

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -32,6 +32,7 @@ type Dialect interface {
 	AutoIncrement(column *ColumnElem) string
 	SupportsUnsigned() bool
 	Driver() string
+	ExtractError(err error, stmt *Stmt) Error
 }
 
 // common escape all

--- a/dialect_default.go
+++ b/dialect_default.go
@@ -57,3 +57,9 @@ func (d *DefaultDialect) Driver() string {
 func (d *DefaultDialect) GetCompiler() Compiler {
 	return SQLCompiler{d}
 }
+
+// ExtractError implements the dialect interface.
+// ATM the default dialect does not extract any specific error
+func (d *DefaultDialect) ExtractError(err error, stmt *Stmt) Error {
+	return NewQbError(err, stmt)
+}

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -73,6 +73,12 @@ func (d *MysqlDialect) GetCompiler() Compiler {
 	return MysqlCompiler{SQLCompiler{d}}
 }
 
+// ExtractError implements the dialect interface.
+// ATM the mysql dialect does not extract any specific error
+func (d *MysqlDialect) ExtractError(err error, stmt *Stmt) Error {
+	return NewQbError(err, stmt)
+}
+
 // MysqlCompiler is a SQLCompiler specialised for Mysql
 type MysqlCompiler struct {
 	SQLCompiler

--- a/dialect_sqlite.go
+++ b/dialect_sqlite.go
@@ -3,6 +3,8 @@ package qb
 import (
 	"fmt"
 	"strings"
+
+	"github.com/mattn/go-sqlite3"
 )
 
 // SqliteDialect is a type of dialect that can be used with sqlite driver
@@ -75,7 +77,22 @@ func (d *SqliteDialect) GetCompiler() Compiler {
 // ExtractError implements the dialect interface.
 // ATM the sqlite dialect does not extract any specific error
 func (d *SqliteDialect) ExtractError(err error, stmt *Stmt) Error {
-	return NewQbError(err, stmt)
+	qbErr := NewQbError(err, stmt)
+	slErr, ok := err.(sqlite3.Error)
+	if !ok {
+		return qbErr
+	}
+	switch {
+	case slErr.Code == sqlite3.ErrConstraint:
+		// we have a Constraint error, return a specific error
+		tokens := strings.Split(slErr.Error(), ": ")
+		return IntegrityError{
+			QbError:    qbErr,
+			Constraint: tokens[len(tokens)-1],
+		}
+	default:
+		return qbErr
+	}
 }
 
 // SqliteCompiler is a SQLCompiler specialised for Sqlite

--- a/dialect_sqlite.go
+++ b/dialect_sqlite.go
@@ -72,6 +72,12 @@ func (d *SqliteDialect) GetCompiler() Compiler {
 	return SqliteCompiler{SQLCompiler{d}}
 }
 
+// ExtractError implements the dialect interface.
+// ATM the sqlite dialect does not extract any specific error
+func (d *SqliteDialect) ExtractError(err error, stmt *Stmt) Error {
+	return NewQbError(err, stmt)
+}
+
 // SqliteCompiler is a SQLCompiler specialised for Sqlite
 type SqliteCompiler struct {
 	SQLCompiler

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"testing"
+	"errors"
 )
 
 type DialectTestSuite struct {
@@ -37,6 +38,8 @@ func (suite *DialectTestSuite) TestDefaultDialect() {
 		"INT PRIMARY KEY AUTO INCREMENT",
 		suite.def.AutoIncrement(&autoincCol))
 
+	err := errors.New("some error")
+	assert.Equal(suite.T(), NewQbError(err, nil), suite.def.ExtractError(err, nil))
 }
 
 func (suite *DialectTestSuite) TestMysqlDialect() {

--- a/errors.go
+++ b/errors.go
@@ -11,7 +11,7 @@ func NewQbError(err error, stmt *Stmt) QbError {
 }
 
 type QbError struct {
-	orig error
+	orig      error
 	Statement *Stmt
 }
 

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,40 @@
+package qb
+
+type Error interface {
+	error
+	Orig() error
+	Stmt() *Stmt
+}
+
+func NewQbError(err error, stmt *Stmt) QbError {
+	return QbError{err, stmt}
+}
+
+type QbError struct {
+	orig error
+	Statement *Stmt
+}
+
+func (e QbError) Error() string {
+	return e.orig.Error()
+}
+
+func (e QbError) Stmt() *Stmt {
+	return e.Statement
+}
+
+func (e QbError) Orig() error {
+	return e.orig
+}
+
+// IntegrityError is an error that can be returned by a qb.dialect
+// if a constraint is violated
+type IntegrityError struct {
+	QbError
+	Constraint string
+}
+
+// Error implements the error interface
+func (e IntegrityError) Error() string {
+	return "constraint error: " + e.Constraint
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,17 @@
+package qb
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestError(t *testing.T) {
+	myErr := errors.New("some error")
+	stmt := Stmt{}
+	qbErr := NewQbError(myErr, &stmt)
+	assert.Equal(t, "some error", qbErr.Error())
+	assert.Equal(t, &stmt, qbErr.Stmt())
+	assert.Equal(t, myErr, qbErr.Orig())
+}

--- a/mysql_test.go
+++ b/mysql_test.go
@@ -2,12 +2,14 @@ package qb
 
 import (
 	"database/sql"
-	_ "github.com/go-sql-driver/mysql"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
+	"errors"
 	"os"
 	"testing"
 	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
 var mysqlDsn = "root:@tcp(localhost:3306)/qb_test?charset=utf8"
@@ -104,6 +106,9 @@ func (suite *MysqlTestSuite) TestMysql() {
 
 	res, err := suite.engine.Exec(ins)
 	assert.Nil(suite.T(), err)
+	if err != nil {
+		suite.T().Fatal(err)
+	}
 
 	lastInsertID, err := res.LastInsertId()
 	assert.Nil(suite.T(), err)
@@ -163,6 +168,15 @@ func (suite *MysqlTestSuite) TestMysql() {
 
 	// drop tables
 	assert.Nil(suite.T(), suite.metadata.DropAll(suite.engine))
+}
+
+func TestMySQLExtractError(t *testing.T) {
+	engine, err := New("mysql", mysqlDsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	myErr := errors.New("some error")
+	assert.Equal(t, NewQbError(myErr, nil), engine.dialect.ExtractError(myErr, nil))
 }
 
 func TestMysqlTestSuite(t *testing.T) {

--- a/postgres_test.go
+++ b/postgres_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/lib/pq"
+	"github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -229,5 +229,14 @@ func TestPostGresDialectExtractError(t *testing.T) {
 		t.Fatal(err)
 	}
 	myErr := errors.New("some error")
+	assert.Equal(t, NewQbError(myErr, nil), pg.dialect.ExtractError(myErr, nil))
+}
+
+func TestPostGresDialectExtractPGError(t *testing.T) {
+	pg, err := New("postgres", postgresDsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	myErr := pq.Error{}
 	assert.Equal(t, NewQbError(myErr, nil), pg.dialect.ExtractError(myErr, nil))
 }

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"testing"
 	"time"
+	"errors"
 )
 
 type SqliteTestSuite struct {
@@ -150,6 +151,15 @@ func (suite *SqliteTestSuite) TestSqlite() {
 
 	// drop tables
 	assert.Nil(suite.T(), suite.metadata.DropAll(suite.engine))
+}
+
+func TestSQLiteExtractError(t *testing.T) {
+	engine, err := New("sqlite3", "./qb_test.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	myErr := errors.New("some error")
+	assert.Equal(t, NewQbError(myErr, nil), engine.dialect.ExtractError(myErr, nil))
 }
 
 func (suite *SqliteTestSuite) TestSqliteAutoIncrement() {

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 	"errors"
+	"github.com/mattn/go-sqlite3"
 )
 
 type SqliteTestSuite struct {
@@ -19,7 +20,7 @@ type SqliteTestSuite struct {
 func (suite *SqliteTestSuite) SetupTest() {
 	var err error
 
-	suite.engine, err = New("sqlite3", "./qb_test.db")
+	suite.engine, err = New("sqlite3", ":memory:")
 	suite.engine.Logger().SetLogFlags(LQuery | LBindings)
 	suite.engine.Dialect().SetEscaping(true)
 
@@ -85,6 +86,30 @@ func (suite *SqliteTestSuite) TestSqlite() {
 
 	_, err = suite.engine.Exec(ins)
 	assert.Nil(suite.T(), err)
+
+	// duplicate constraint should return a proper ConstraintViolation
+	_, err = suite.engine.Exec(ins)
+	assert.Error(suite.T(), err, "this insert should return an error")
+	integErr, ok := err.(IntegrityError)
+	if !ok {
+		suite.T().Fatalf("we should have received an integrity error")
+	}
+
+	// we assert on multiple constraints because SQLite returns one of the
+	// two violated constraint in a random order
+	assert.Contains(
+		suite.T(),
+		[]string{"users.email", "users.id"},
+		integErr.Constraint,
+	)
+	assert.Contains(
+		suite.T(),
+		[]string{
+			"UNIQUE constraint failed: users.email",
+			"UNIQUE constraint failed: users.id",
+		},
+		integErr.Orig().Error(),
+	)
 
 	ins = Insert(sessions).Values(map[string]interface{}{
 		"user_id":    "b6f8bfe3-a830-441a-a097-1777e6bfae95",
@@ -154,7 +179,7 @@ func (suite *SqliteTestSuite) TestSqlite() {
 }
 
 func TestSQLiteExtractError(t *testing.T) {
-	engine, err := New("sqlite3", "./qb_test.db")
+	engine, err := New("sqlite3", ":memory:")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,4 +196,22 @@ func (suite *SqliteTestSuite) TestSqliteAutoIncrement() {
 
 func TestSqliteTestSuite(t *testing.T) {
 	suite.Run(t, new(SqliteTestSuite))
+}
+
+func TestSQLiteDialectExtractError(t *testing.T) {
+	sq, err := New("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	myErr := errors.New("some error")
+	assert.Equal(t, NewQbError(myErr, nil), sq.dialect.ExtractError(myErr, nil))
+}
+
+func TestSQLiteDialectExtractSQLiteError(t *testing.T) {
+	sq, err := New("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	myErr := sqlite3.Error{}
+	assert.Equal(t, NewQbError(myErr, nil), sq.dialect.ExtractError(myErr, nil))
 }


### PR DESCRIPTION
allows better control on the specific errors we return to help implementers find specific errors like Integrity Errors