### PR TITLE
Simplify tests

### DIFF
--- a/column_test.go
+++ b/column_test.go
@@ -6,162 +6,89 @@ import (
 )
 
 func TestColumn(t *testing.T) {
-	sqlite := NewDialect("sqlite3")
-	sqlite.SetEscaping(true)
-
-	mysql := NewDialect("mysql")
-	mysql.SetEscaping(true)
-
-	postgres := NewDialect("postgres")
-	postgres.SetEscaping(true)
+	dialect := NewDialect("default")
 
 	col := Column("id", Varchar().Size(40))
 	assert.Equal(t, "id", col.Name)
 	assert.Equal(t, Varchar().Size(40), col.Type)
 
-	assert.Equal(t, "\"id\" VARCHAR(40)", col.String(sqlite))
-	assert.Equal(t, "`id` VARCHAR(40)", col.String(mysql))
-	assert.Equal(t, "\"id\" VARCHAR(40)", col.String(postgres))
+	assert.Equal(t, "id VARCHAR(40)", col.String(dialect))
 
 	col = Column("s", Varchar().Size(255)).Unique().NotNull().Default("hello")
-	assert.Equal(t, "\"s\" VARCHAR(255) UNIQUE NOT NULL DEFAULT 'hello'", col.String(sqlite))
+	assert.Equal(t, "s VARCHAR(255) UNIQUE NOT NULL DEFAULT 'hello'", col.String(dialect))
 
 	precisionCol := Column("f", Type("FLOAT").Precision(2, 5)).Null()
-	assert.Equal(t, "\"f\" FLOAT(2, 5) NULL", precisionCol.String(sqlite))
+	assert.Equal(t, "f FLOAT(2, 5) NULL", precisionCol.String(dialect))
 
 	col = Column("id", Int()).PrimaryKey().AutoIncrement().inlinePrimaryKey()
 
-	assert.Equal(t, "\"id\" INTEGER PRIMARY KEY", col.String(sqlite))
-	assert.Equal(t, "`id` INT PRIMARY KEY AUTO_INCREMENT", col.String(mysql))
-	assert.Equal(t, "\"id\" SERIAL PRIMARY KEY", col.String(postgres))
+	assert.Equal(t, "id INT PRIMARY KEY AUTO INCREMENT", col.String(dialect))
 
-	assert.Equal(t, "\"c\" INT TEST", Column("c", Int()).Constraint("TEST").String(sqlite))
+	assert.Equal(t, "c INT TEST", Column("c", Int()).Constraint("TEST").String(dialect))
 
 	// like
 	like := col.Like("s%")
-	likeSqlite, likeBindingsSqlite := asSQLBinds(like, sqlite)
-	likeMysql, likeBindingsMysql := asSQLBinds(like, mysql)
-	likePostgres, likeBindingsPostgres := asSQLBinds(like, postgres)
+	sql, binds := asDefSQLBinds(like)
 
-	assert.Equal(t, "\"id\" LIKE ?", likeSqlite)
-	assert.Equal(t, []interface{}{"s%"}, likeBindingsSqlite)
-	assert.Equal(t, "`id` LIKE ?", likeMysql)
-	assert.Equal(t, []interface{}{"s%"}, likeBindingsMysql)
-	assert.Equal(t, "\"id\" LIKE $1", likePostgres)
-	assert.Equal(t, []interface{}{"s%"}, likeBindingsPostgres)
+	assert.Equal(t, "id LIKE ?", sql)
+	assert.Equal(t, []interface{}{"s%"}, binds)
 
 	// not in
 	notIn := col.NotIn("id1", "id2")
-	notInSqlite, likeBindingsSqlite := asSQLBinds(notIn, sqlite)
-	notInMysql, likeBindingsMysql := asSQLBinds(notIn, mysql)
-	notInPostgres, likeBindingsPostgres := asSQLBinds(notIn, postgres)
+	sql, binds = asDefSQLBinds(notIn)
 
-	assert.Equal(t, "\"id\" NOT IN (?, ?)", notInSqlite)
-	assert.Equal(t, []interface{}{"id1", "id2"}, likeBindingsSqlite)
-	assert.Equal(t, "`id` NOT IN (?, ?)", notInMysql)
-	assert.Equal(t, []interface{}{"id1", "id2"}, likeBindingsMysql)
-	assert.Equal(t, "\"id\" NOT IN ($1, $2)", notInPostgres)
-	assert.Equal(t, []interface{}{"id1", "id2"}, likeBindingsPostgres)
+	assert.Equal(t, "id NOT IN (?, ?)", sql)
+	assert.Equal(t, []interface{}{"id1", "id2"}, binds)
 
 	// in
 	in := col.In("id1", "id2")
-	inSqlite, likeBindingsSqlite := asSQLBinds(in, sqlite)
-	inMysql, likeBindingsMysql := asSQLBinds(in, mysql)
-	inPostgres, likeBindingsPostgres := asSQLBinds(in, postgres)
+	sql, binds = asDefSQLBinds(in)
 
-	assert.Equal(t, "\"id\" IN (?, ?)", inSqlite)
-	assert.Equal(t, []interface{}{"id1", "id2"}, likeBindingsSqlite)
-	assert.Equal(t, "`id` IN (?, ?)", inMysql)
-	assert.Equal(t, []interface{}{"id1", "id2"}, likeBindingsMysql)
-	assert.Equal(t, "\"id\" IN ($1, $2)", inPostgres)
-	assert.Equal(t, []interface{}{"id1", "id2"}, likeBindingsPostgres)
+	assert.Equal(t, "id IN (?, ?)", sql)
+	assert.Equal(t, []interface{}{"id1", "id2"}, binds)
 
 	// not eq
 	notEq := col.NotEq("id1")
-	notEqSqlite, likeBindingsSqlite := asSQLBinds(notEq, sqlite)
-	notEqMysql, likeBindingsMysql := asSQLBinds(notEq, mysql)
-	notEqPostgres, likeBindingsPostgres := asSQLBinds(notEq, postgres)
+	sql, binds = asDefSQLBinds(notEq)
 
-	assert.Equal(t, "\"id\" != ?", notEqSqlite)
-	assert.Equal(t, []interface{}{"id1"}, likeBindingsSqlite)
-	assert.Equal(t, "`id` != ?", notEqMysql)
-	assert.Equal(t, []interface{}{"id1"}, likeBindingsMysql)
-	assert.Equal(t, "\"id\" != $1", notEqPostgres)
-	assert.Equal(t, []interface{}{"id1"}, likeBindingsPostgres)
+	assert.Equal(t, "id != ?", sql)
+	assert.Equal(t, []interface{}{"id1"}, binds)
 
 	// eq
 	eq := col.Eq("id1")
-	eqSqlite, likeBindingsSqlite := asSQLBinds(eq, sqlite)
-	eqMysql, likeBindingsMysql := asSQLBinds(eq, mysql)
-	eqPostgres, likeBindingsPostgres := asSQLBinds(eq, postgres)
+	sql, binds = asDefSQLBinds(eq)
 
-	assert.Equal(t, "\"id\" = ?", eqSqlite)
-	assert.Equal(t, []interface{}{"id1"}, likeBindingsSqlite)
-	assert.Equal(t, "`id` = ?", eqMysql)
-	assert.Equal(t, []interface{}{"id1"}, likeBindingsMysql)
-	assert.Equal(t, "\"id\" = $1", eqPostgres)
-	assert.Equal(t, []interface{}{"id1"}, likeBindingsPostgres)
+	assert.Equal(t, "id = ?", sql)
+	assert.Equal(t, []interface{}{"id1"}, binds)
 
 	// gt
 	gt := col.Gt("id1")
-	gtSqlite, likeBindingsSqlite := asSQLBinds(gt, sqlite)
-	gtMysql, likeBindingsMysql := asSQLBinds(gt, mysql)
-	gtPostgres, likeBindingsPostgres := asSQLBinds(gt, postgres)
+	sql, binds = asDefSQLBinds(gt)
 
-	assert.Equal(t, "\"id\" > ?", gtSqlite)
-	assert.Equal(t, []interface{}{"id1"}, likeBindingsSqlite)
-	assert.Equal(t, "`id` > ?", gtMysql)
-	assert.Equal(t, []interface{}{"id1"}, likeBindingsMysql)
-	assert.Equal(t, "\"id\" > $1", gtPostgres)
-	assert.Equal(t, []interface{}{"id1"}, likeBindingsPostgres)
+	assert.Equal(t, "id > ?", sql)
+	assert.Equal(t, []interface{}{"id1"}, binds)
 
 	// lt
 	lt := col.Lt("id1")
-	ltSqlite, likeBindingsSqlite := asSQLBinds(lt, sqlite)
-	ltMysql, likeBindingsMysql := asSQLBinds(lt, mysql)
-	ltPostgres, likeBindingsPostgres := asSQLBinds(lt, postgres)
+	sql, binds = asDefSQLBinds(lt)
 
-	assert.Equal(t, "\"id\" < ?", ltSqlite)
-	assert.Equal(t, []interface{}{"id1"}, likeBindingsSqlite)
-	assert.Equal(t, "`id` < ?", ltMysql)
-	assert.Equal(t, []interface{}{"id1"}, likeBindingsMysql)
-	assert.Equal(t, "\"id\" < $1", ltPostgres)
-	assert.Equal(t, []interface{}{"id1"}, likeBindingsPostgres)
+	assert.Equal(t, "id < ?", sql)
+	assert.Equal(t, []interface{}{"id1"}, binds)
 
 	// gte
 	gte := col.Gte("id1")
-	gteSqlite, likeBindingsSqlite := asSQLBinds(gte, sqlite)
-	gteMysql, likeBindingsMysql := asSQLBinds(gte, mysql)
-	gtePostgres, likeBindingsPostgres := asSQLBinds(gte, postgres)
+	sql, binds = asDefSQLBinds(gte)
 
-	assert.Equal(t, "\"id\" >= ?", gteSqlite)
-	assert.Equal(t, []interface{}{"id1"}, likeBindingsSqlite)
-	assert.Equal(t, "`id` >= ?", gteMysql)
-	assert.Equal(t, []interface{}{"id1"}, likeBindingsMysql)
-	assert.Equal(t, "\"id\" >= $1", gtePostgres)
-	assert.Equal(t, []interface{}{"id1"}, likeBindingsPostgres)
+	assert.Equal(t, "id >= ?", sql)
+	assert.Equal(t, []interface{}{"id1"}, binds)
 
 	// lte
 	lte := col.Lte("id1")
-	lteSqlite, likeBindingsSqlite := asSQLBinds(lte, sqlite)
-	lteMysql, likeBindingsMysql := asSQLBinds(lte, mysql)
-	ltePostgres, likeBindingsPostgres := asSQLBinds(lte, postgres)
+	sql, binds = asDefSQLBinds(lte)
 
-	assert.Equal(t, "\"id\" <= ?", lteSqlite)
-	assert.Equal(t, []interface{}{"id1"}, likeBindingsSqlite)
-	assert.Equal(t, "`id` <= ?", lteMysql)
-	assert.Equal(t, []interface{}{"id1"}, likeBindingsMysql)
-	assert.Equal(t, "\"id\" <= $1", ltePostgres)
-	assert.Equal(t, []interface{}{"id1"}, likeBindingsPostgres)
+	assert.Equal(t, "id <= ?", sql)
+	assert.Equal(t, []interface{}{"id1"}, binds)
 
-	var sql string
-
-	sql = col.Accept(NewCompilerContext(sqlite))
-	assert.Equal(t, "\"id\"", sql)
-
-	sql = col.Accept(NewCompilerContext(mysql))
-	assert.Equal(t, "`id`", sql)
-
-	sql = col.Accept(NewCompilerContext(postgres))
-	assert.Equal(t, "\"id\"", sql)
+	sql = col.Accept(NewCompilerContext(dialect))
+	assert.Equal(t, "id", sql)
 }

--- a/combiner_test.go
+++ b/combiner_test.go
@@ -6,55 +6,19 @@ import (
 )
 
 func TestCombiners(t *testing.T) {
-	sqlite := NewDialect("sqlite3")
-	sqlite.SetEscaping(true)
-
-	mysql := NewDialect("mysql")
-	mysql.SetEscaping(true)
-
-	postgres := NewDialect("postgres")
-	postgres.SetEscaping(true)
-
 	email := Column("email", Varchar()).NotNull().Unique()
 	id := Column("id", Int()).NotNull()
 
 	and := And(Eq(email, "al@pacino.com"), NotEq(id, 1))
 	or := Or(Eq(email, "al@pacino.com"), NotEq(id, 1))
 
-	var sql string
-	ctx := NewCompilerContext(sqlite)
-	sql = and.Accept(ctx)
+	sql, binds := asDefSQLBinds(and)
 
-	assert.Equal(t, "(\"email\" = ? AND \"id\" != ?)", sql)
-	assert.Equal(t, []interface{}{"al@pacino.com", 1}, ctx.Binds)
+	assert.Equal(t, "(email = ? AND id != ?)", sql)
+	assert.Equal(t, []interface{}{"al@pacino.com", 1}, binds)
 
-	ctx = NewCompilerContext(mysql)
-	sql = and.Accept(ctx)
+	sql, binds = asDefSQLBinds(or)
 
-	assert.Equal(t, "(`email` = ? AND `id` != ?)", sql)
-	assert.Equal(t, []interface{}{"al@pacino.com", 1}, ctx.Binds)
-
-	ctx = NewCompilerContext(postgres)
-	sql = and.Accept(ctx)
-
-	assert.Equal(t, "(\"email\" = $1 AND \"id\" != $2)", sql)
-	assert.Equal(t, []interface{}{"al@pacino.com", 1}, ctx.Binds)
-
-	ctx = NewCompilerContext(sqlite)
-	sql = or.Accept(ctx)
-
-	assert.Equal(t, "(\"email\" = ? OR \"id\" != ?)", sql)
-	assert.Equal(t, []interface{}{"al@pacino.com", 1}, ctx.Binds)
-
-	ctx = NewCompilerContext(mysql)
-	sql = or.Accept(ctx)
-
-	assert.Equal(t, "(`email` = ? OR `id` != ?)", sql)
-	assert.Equal(t, []interface{}{"al@pacino.com", 1}, ctx.Binds)
-
-	ctx = NewCompilerContext(postgres)
-	sql = or.Accept(ctx)
-
-	assert.Equal(t, "(\"email\" = $1 OR \"id\" != $2)", sql)
-	assert.Equal(t, []interface{}{"al@pacino.com", 1}, ctx.Binds)
+	assert.Equal(t, "(email = ? OR id != ?)", sql)
+	assert.Equal(t, []interface{}{"al@pacino.com", 1}, binds)
 }

--- a/conditional_test.go
+++ b/conditional_test.go
@@ -6,21 +6,6 @@ import (
 )
 
 func TestConditionals(t *testing.T) {
-
-	compile := func(c Clause, d Dialect) (string, []interface{}) {
-		ctx := NewCompilerContext(d)
-		return c.Accept(ctx), ctx.Binds
-	}
-
-	sqlite := NewDialect("sqlite3")
-	sqlite.SetEscaping(true)
-
-	mysql := NewDialect("mysql")
-	mysql.SetEscaping(true)
-
-	postgres := NewDialect("postgres")
-	postgres.SetEscaping(true)
-
 	country := Column("country", Varchar()).NotNull()
 
 	var sql string
@@ -28,132 +13,57 @@ func TestConditionals(t *testing.T) {
 
 	like := Like(country, "%land%")
 
-	sql, bindings = compile(like, sqlite)
-	assert.Equal(t, "\"country\" LIKE ?", sql)
-	assert.Equal(t, []interface{}{"%land%"}, bindings)
-
-	sql, _ = compile(like, mysql)
-	assert.Equal(t, "`country` LIKE ?", sql)
-	assert.Equal(t, []interface{}{"%land%"}, bindings)
-
-	sql, _ = compile(like, postgres)
-	assert.Equal(t, "\"country\" LIKE $1", sql)
+	sql, bindings = asDefSQLBinds(like)
+	assert.Equal(t, "country LIKE ?", sql)
 	assert.Equal(t, []interface{}{"%land%"}, bindings)
 
 	notIn := NotIn(country, "USA", "England", "Sweden")
 
-	sql, bindings = compile(notIn, sqlite)
-	assert.Equal(t, "\"country\" NOT IN (?, ?, ?)", sql)
-	assert.Equal(t, []interface{}{"USA", "England", "Sweden"}, bindings)
-
-	sql, bindings = compile(notIn, mysql)
-	assert.Equal(t, "`country` NOT IN (?, ?, ?)", sql)
-	assert.Equal(t, []interface{}{"USA", "England", "Sweden"}, bindings)
-
-	sql, bindings = compile(notIn, postgres)
-	assert.Equal(t, "\"country\" NOT IN ($1, $2, $3)", sql)
+	sql, bindings = asDefSQLBinds(notIn)
+	assert.Equal(t, "country NOT IN (?, ?, ?)", sql)
 	assert.Equal(t, []interface{}{"USA", "England", "Sweden"}, bindings)
 
 	in := In(country, "USA", "England", "Sweden")
 
-	sql, bindings = compile(in, sqlite)
-	assert.Equal(t, "\"country\" IN (?, ?, ?)", sql)
-	assert.Equal(t, []interface{}{"USA", "England", "Sweden"}, bindings)
-
-	sql, bindings = compile(in, mysql)
-	assert.Equal(t, "`country` IN (?, ?, ?)", sql)
-	assert.Equal(t, []interface{}{"USA", "England", "Sweden"}, bindings)
-
-	sql, bindings = compile(in, postgres)
-	assert.Equal(t, "\"country\" IN ($1, $2, $3)", sql)
+	sql, bindings = asDefSQLBinds(in)
+	assert.Equal(t, "country IN (?, ?, ?)", sql)
 	assert.Equal(t, []interface{}{"USA", "England", "Sweden"}, bindings)
 
 	notEq := NotEq(country, "USA")
 
-	sql, bindings = compile(notEq, sqlite)
-	assert.Equal(t, "\"country\" != ?", sql)
-	assert.Equal(t, []interface{}{"USA"}, bindings)
-
-	sql, bindings = compile(notEq, mysql)
-	assert.Equal(t, "`country` != ?", sql)
-	assert.Equal(t, []interface{}{"USA"}, bindings)
-
-	sql, bindings = compile(notEq, postgres)
-	assert.Equal(t, "\"country\" != $1", sql)
+	sql, bindings = asDefSQLBinds(notEq)
+	assert.Equal(t, "country != ?", sql)
 	assert.Equal(t, []interface{}{"USA"}, bindings)
 
 	eq := Eq(country, "Turkey")
 
-	sql, bindings = compile(eq, sqlite)
-	assert.Equal(t, "\"country\" = ?", sql)
-	assert.Equal(t, []interface{}{"Turkey"}, bindings)
-
-	sql, bindings = compile(eq, mysql)
-	assert.Equal(t, "`country` = ?", sql)
-	assert.Equal(t, []interface{}{"Turkey"}, bindings)
-
-	sql, bindings = compile(eq, postgres)
-	assert.Equal(t, "\"country\" = $1", sql)
+	sql, bindings = asDefSQLBinds(eq)
+	assert.Equal(t, "country = ?", sql)
 	assert.Equal(t, []interface{}{"Turkey"}, bindings)
 
 	score := Column("score", BigInt()).NotNull()
 
 	gt := Gt(score, 1500)
 
-	sql, bindings = compile(gt, sqlite)
-	assert.Equal(t, "\"score\" > ?", sql)
-	assert.Equal(t, []interface{}{1500}, bindings)
-
-	sql, bindings = compile(gt, mysql)
-	assert.Equal(t, "`score` > ?", sql)
-	assert.Equal(t, []interface{}{1500}, bindings)
-
-	sql, bindings = compile(gt, postgres)
-	assert.Equal(t, "\"score\" > $1", sql)
+	sql, bindings = asDefSQLBinds(gt)
+	assert.Equal(t, "score > ?", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
 	lt := Lt(score, 1500)
 
-	sql, bindings = compile(lt, sqlite)
-	assert.Equal(t, "\"score\" < ?", sql)
-	assert.Equal(t, []interface{}{1500}, bindings)
-
-	sql, bindings = compile(lt, mysql)
-	assert.Equal(t, "`score` < ?", sql)
-	assert.Equal(t, []interface{}{1500}, bindings)
-
-	sql, bindings = compile(lt, postgres)
-
-	assert.Equal(t, "\"score\" < $1", sql)
+	sql, bindings = asDefSQLBinds(lt)
+	assert.Equal(t, "score < ?", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
 	gte := Gte(score, 1500)
 
-	sql, bindings = compile(gte, sqlite)
-	assert.Equal(t, "\"score\" >= ?", sql)
-	assert.Equal(t, []interface{}{1500}, bindings)
-
-	sql, bindings = compile(gte, mysql)
-	assert.Equal(t, "`score` >= ?", sql)
-	assert.Equal(t, []interface{}{1500}, bindings)
-
-	sql, bindings = compile(gte, postgres)
-	assert.Equal(t, "\"score\" >= $1", sql)
+	sql, bindings = asDefSQLBinds(gte)
+	assert.Equal(t, "score >= ?", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
 
 	lte := Lte(score, 1500)
 
-	sql, bindings = compile(lte, sqlite)
-	assert.Equal(t, "\"score\" <= ?", sql)
+	sql, bindings = asDefSQLBinds(lte)
+	assert.Equal(t, "score <= ?", sql)
 	assert.Equal(t, []interface{}{1500}, bindings)
-
-	sql, bindings = compile(lte, mysql)
-	assert.Equal(t, "`score` <= ?", sql)
-	assert.Equal(t, []interface{}{1500}, bindings)
-
-	sql, bindings = compile(lte, postgres)
-
-	assert.Equal(t, "\"score\" <= $1", sql)
-	assert.Equal(t, []interface{}{1500}, bindings)
-
 }

--- a/delete_test.go
+++ b/delete_test.go
@@ -6,14 +6,7 @@ import (
 )
 
 func TestDelete(t *testing.T) {
-	sqlite := NewDialect("sqlite3")
-	sqlite.SetEscaping(true)
-
-	mysql := NewDialect("mysql")
-	mysql.SetEscaping(true)
-
-	postgres := NewDialect("postgres")
-	postgres.SetEscaping(true)
+	dialect := NewDialect("default")
 
 	users := Table(
 		"users",
@@ -25,26 +18,19 @@ func TestDelete(t *testing.T) {
 
 	statement = Delete(users).
 		Where(Eq(users.C("id"), 5)).
-		Build(sqlite)
+		Build(dialect)
 
-	assert.Equal(t, "DELETE FROM \"users\"\nWHERE \"users\".\"id\" = ?;", statement.SQL())
-	assert.Equal(t, []interface{}{5}, statement.Bindings())
-
-	statement = Delete(users).
-		Where(Eq(users.C("id"), 5)).
-		Build(mysql)
-
-	assert.Equal(t, "DELETE FROM `users`\nWHERE `users`.`id` = ?;", statement.SQL())
+	assert.Equal(t, "DELETE FROM users\nWHERE users.id = ?;", statement.SQL())
 	assert.Equal(t, []interface{}{5}, statement.Bindings())
 
 	statement = Delete(users).
 		Where(Eq(users.C("id"), 5)).
 		Returning(users.C("id")).
-		Build(postgres)
+		Build(dialect)
 
-	assert.Equal(t, "DELETE FROM \"users\"\nWHERE \"users\".\"id\" = $1\nRETURNING \"id\";", statement.SQL())
+	assert.Equal(t, "DELETE FROM users\nWHERE users.id = ?\nRETURNING id;", statement.SQL())
 	assert.Equal(t, []interface{}{5}, statement.Bindings())
 
-	statement = Delete(users).Build(sqlite)
-	assert.Equal(t, "DELETE FROM \"users\";", statement.SQL())
+	statement = Delete(users).Build(dialect)
+	assert.Equal(t, "DELETE FROM users;", statement.SQL())
 }

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -2,85 +2,23 @@ package qb
 
 import (
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
 	"testing"
 )
 
-type DialectTestSuite struct {
-	suite.Suite
-	postgres Dialect
-	mysql    Dialect
-	sqlite   Dialect
-	def      Dialect
-}
-
-func (suite *DialectTestSuite) SetupTest() {
-	suite.postgres = NewDialect("postgres")
-	suite.mysql = NewDialect("mysql")
-	suite.sqlite = NewDialect("sqlite3")
-	suite.def = NewDialect("default")
-}
-
-func (suite *DialectTestSuite) TestDefaultDialect() {
-	assert.Implements(suite.T(), (*Compiler)(nil), suite.def.GetCompiler())
-	assert.Equal(suite.T(), false, suite.def.SupportsUnsigned())
-	assert.Equal(suite.T(), "test", suite.def.Escape("test"))
-	assert.Equal(suite.T(), false, suite.def.Escaping())
-	suite.def.SetEscaping(true)
-	assert.Equal(suite.T(), true, suite.def.Escaping())
-	assert.Equal(suite.T(), "`test`", suite.def.Escape("test"))
-	assert.Equal(suite.T(), []string{"`test`"}, suite.def.EscapeAll([]string{"test"}))
-	assert.Equal(suite.T(), "", suite.def.Driver())
+func TestDefaultDialect(t *testing.T) {
+	dialect := NewDialect("default")
+	assert.Implements(t, (*Compiler)(nil), dialect.GetCompiler())
+	assert.Equal(t, false, dialect.SupportsUnsigned())
+	assert.Equal(t, "test", dialect.Escape("test"))
+	assert.Equal(t, false, dialect.Escaping())
+	dialect.SetEscaping(true)
+	assert.Equal(t, true, dialect.Escaping())
+	assert.Equal(t, "`test`", dialect.Escape("test"))
+	assert.Equal(t, []string{"`test`"}, dialect.EscapeAll([]string{"test"}))
+	assert.Equal(t, "", dialect.Driver())
 
 	autoincCol := Column("id", Int()).PrimaryKey().AutoIncrement()
-	assert.Equal(suite.T(),
+	assert.Equal(t,
 		"INT PRIMARY KEY AUTO INCREMENT",
-		suite.def.AutoIncrement(&autoincCol))
-
-}
-
-func (suite *DialectTestSuite) TestMysqlDialect() {
-	assert.Equal(suite.T(), true, suite.mysql.SupportsUnsigned())
-	assert.Equal(suite.T(), "test", suite.mysql.Escape("test"))
-	assert.Equal(suite.T(), false, suite.mysql.Escaping())
-	suite.mysql.SetEscaping(true)
-	assert.Equal(suite.T(), true, suite.mysql.Escaping())
-	assert.Equal(suite.T(), "`test`", suite.mysql.Escape("test"))
-	assert.Equal(suite.T(), []string{"`test`"}, suite.mysql.EscapeAll([]string{"test"}))
-	assert.Equal(suite.T(), "mysql", suite.mysql.Driver())
-}
-
-func (suite *DialectTestSuite) TestPostgresDialect() {
-	assert.Equal(suite.T(), false, suite.postgres.SupportsUnsigned())
-	assert.Equal(suite.T(), "test", suite.postgres.Escape("test"))
-	assert.Equal(suite.T(), false, suite.postgres.Escaping())
-	suite.postgres.SetEscaping(true)
-	assert.Equal(suite.T(), true, suite.postgres.Escaping())
-	assert.Equal(suite.T(), "\"test\"", suite.postgres.Escape("test"))
-	assert.Equal(suite.T(), []string{"\"test\""}, suite.postgres.EscapeAll([]string{"test"}))
-	assert.Equal(suite.T(), "postgres", suite.postgres.Driver())
-
-	col := Column("autoinc", Int()).AutoIncrement()
-	assert.Equal(suite.T(), "SERIAL", suite.postgres.AutoIncrement(&col))
-
-	col = Column("autoinc", BigInt()).AutoIncrement()
-	assert.Equal(suite.T(), "BIGSERIAL", suite.postgres.AutoIncrement(&col))
-
-	col = Column("autoinc", SmallInt()).AutoIncrement()
-	assert.Equal(suite.T(), "SMALLSERIAL", suite.postgres.AutoIncrement(&col))
-}
-
-func (suite *DialectTestSuite) TestSqliteDialect() {
-	assert.Equal(suite.T(), false, suite.sqlite.SupportsUnsigned())
-	assert.Equal(suite.T(), "test", suite.sqlite.Escape("test"))
-	assert.Equal(suite.T(), false, suite.sqlite.Escaping())
-	suite.sqlite.SetEscaping(true)
-	assert.Equal(suite.T(), true, suite.sqlite.Escaping())
-	assert.Equal(suite.T(), "\"test\"", suite.sqlite.Escape("test"))
-	assert.Equal(suite.T(), []string{"\"test\""}, suite.sqlite.EscapeAll([]string{"test"}))
-	assert.Equal(suite.T(), "sqlite3", suite.sqlite.Driver())
-}
-
-func TestDialectTestSuite(t *testing.T) {
-	suite.Run(t, new(DialectTestSuite))
+		dialect.AutoIncrement(&autoincCol))
 }

--- a/engine_test.go
+++ b/engine_test.go
@@ -1,19 +1,18 @@
 package qb
 
 import (
-	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func TestEngine(t *testing.T) {
-	engine, err := New("postgres", "user=root dbname=pqtest")
+	engine, err := New("sqlite3", ":memory:")
 
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "postgres", engine.Driver())
+	assert.Equal(t, "sqlite3", engine.Driver())
 	assert.Equal(t, engine.DB().Ping(), engine.Ping())
-	assert.Equal(t, "user=root dbname=pqtest", engine.Dsn())
+	assert.Equal(t, ":memory:", engine.Dsn())
 }
 
 func TestInvalidEngine(t *testing.T) {
@@ -23,8 +22,8 @@ func TestInvalidEngine(t *testing.T) {
 }
 
 func TestEngineExec(t *testing.T) {
-	engine, err := New("postgres", "user=root dbname=pqtest")
-	dialect := NewDialect("postgres")
+	engine, err := New("sqlite3", ":memory:")
+	dialect := NewDialect("sqlite")
 	dialect.SetEscaping(true)
 	engine.SetDialect(dialect)
 
@@ -147,7 +146,8 @@ func TestTx(t *testing.T) {
 }
 
 func TestTxBeginError(t *testing.T) {
-	engine, err := New("postgres", "invalid_connexion")
+	engine, err := New("sqlite3", "file:///dev/null?_txlock=exclusive")
+	assert.Nil(t, err)
 	_, err = engine.Begin()
 	assert.NotNil(t, err)
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -25,7 +25,7 @@ func TestLogger(t *testing.T) {
 	_, err = engine.Exec(actors.Insert().Values(map[string]interface{}{"id": 5}))
 	assert.Nil(t, err)
 
-	engine.Logger().SetLogFlags(LQuery|LBindings)
+	engine.Logger().SetLogFlags(LQuery | LBindings)
 	_, err = engine.Exec(actors.Insert().Values(map[string]interface{}{"id": 10}))
 	assert.Nil(t, err)
 
@@ -33,7 +33,7 @@ func TestLogger(t *testing.T) {
 }
 
 func TestLoggerFlags(t *testing.T) {
-	engine, err := New("postgres", "user=root dbname=pqtest")
+	engine, err := New("sqlite3", ":memory:")
 	assert.Equal(t, nil, err)
 
 	// before setting flags, this is on the default

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -1,17 +1,28 @@
 package qb
 
 import (
+	"io/ioutil"
+	"os"
+
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func TestMetadataCreateAllDropAllError(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "qbtestdb")
+	if err != nil {
+		t.Fatalf("Cannot create a temporary file. Got '%s'", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	dsn := "file://" + tmpFile.Name()
+	tmpFile.Close()
+
 	accounts := Table(
 		"account",
 		Column("id", Type("UUID")),
 		PrimaryKey("id"),
 	)
-	engine, err := New("postgres", postgresDsn)
+	engine, err := New("sqlite3", dsn)
 	metadata := MetaData()
 
 	engine.Dialect().SetEscaping(true)
@@ -20,7 +31,7 @@ func TestMetadataCreateAllDropAllError(t *testing.T) {
 	err = metadata.CreateAll(engine)
 	assert.Nil(t, err)
 
-	engineNew, err := New("postgres", postgresDsn)
+	engineNew, err := New("sqlite3", dsn)
 	engineNew.Dialect().SetEscaping(true)
 	metadataNew := MetaData()
 	assert.Nil(t, err)
@@ -59,7 +70,7 @@ func TestMetadataTable(t *testing.T) {
 }
 
 func TestMetadataFailCreateDropAll(t *testing.T) {
-	engine, _ := New("postgres", postgresDsn)
+	engine, _ := New("sqlite3", ":memory:")
 	metadata := MetaData()
 
 	var err error
@@ -72,7 +83,7 @@ func TestMetadataFailCreateDropAll(t *testing.T) {
 }
 
 func TestMetadataWithNoConnection(t *testing.T) {
-	engine, _ := New("postgres", postgresDsn)
+	engine, _ := New("sqlite3", ":memory:")
 	engine.DB().Close()
 
 	metadata := MetaData()

--- a/mysql_test.go
+++ b/mysql_test.go
@@ -40,6 +40,18 @@ func (suite *MysqlTestSuite) TestUUID() {
 	assert.Equal(suite.T(), "VARCHAR(36)", suite.engine.Dialect().CompileType(UUID()))
 }
 
+func (suite *MysqlTestSuite) TestDialect() {
+	dialect := NewDialect("mysql")
+	assert.Equal(suite.T(), true, dialect.SupportsUnsigned())
+	assert.Equal(suite.T(), "test", dialect.Escape("test"))
+	assert.Equal(suite.T(), false, dialect.Escaping())
+	dialect.SetEscaping(true)
+	assert.Equal(suite.T(), true, dialect.Escaping())
+	assert.Equal(suite.T(), "`test`", dialect.Escape("test"))
+	assert.Equal(suite.T(), []string{"`test`"}, dialect.EscapeAll([]string{"test"}))
+	assert.Equal(suite.T(), "mysql", dialect.Driver())
+}
+
 func (suite *MysqlTestSuite) TestMysql() {
 	type User struct {
 		ID       string         `db:"id"`

--- a/postgres_test.go
+++ b/postgres_test.go
@@ -197,6 +197,29 @@ func (suite *PostgresTestSuite) TestPostgres() {
 	assert.Nil(suite.T(), suite.metadata.DropAll(suite.engine))
 }
 
+func (suite *PostgresTestSuite) TestAutoIncrement() {
+	col := Column("id", BigInt()).AutoIncrement()
+	assert.Equal(suite.T(),
+		"BIGSERIAL",
+		suite.engine.Dialect().AutoIncrement(&col))
+
+	col = Column("id", SmallInt()).AutoIncrement()
+	assert.Equal(suite.T(),
+		"SMALLSERIAL",
+		suite.engine.Dialect().AutoIncrement(&col))
+
+	col = Column("id", Int()).AutoIncrement()
+	assert.Equal(suite.T(),
+		"SERIAL",
+		suite.engine.Dialect().AutoIncrement(&col))
+
+	col = Column("id", Int()).AutoIncrement()
+	col.Options.InlinePrimaryKey = true
+	assert.Equal(suite.T(),
+		"SERIAL PRIMARY KEY",
+		suite.engine.Dialect().AutoIncrement(&col))
+}
+
 func TestPostgresTestSuite(t *testing.T) {
 	suite.Run(t, new(PostgresTestSuite))
 }

--- a/postgres_test.go
+++ b/postgres_test.go
@@ -38,6 +38,28 @@ func (suite *PostgresTestSuite) TestUUID() {
 	assert.Equal(suite.T(), "UUID", suite.engine.Dialect().CompileType(UUID()))
 }
 
+func (suite *PostgresTestSuite) TestDialect() {
+	dialect := NewDialect("postgres")
+	assert.Equal(suite.T(), false, dialect.SupportsUnsigned())
+	assert.Equal(suite.T(), "test", dialect.Escape("test"))
+	assert.Equal(suite.T(), false, dialect.Escaping())
+	dialect.SetEscaping(true)
+	assert.Equal(suite.T(), true, dialect.Escaping())
+	assert.Equal(suite.T(), "\"test\"", dialect.Escape("test"))
+	assert.Equal(suite.T(), []string{"\"test\""}, dialect.EscapeAll([]string{"test"}))
+	assert.Equal(suite.T(), "postgres", dialect.Driver())
+
+	col := Column("autoinc", Int()).AutoIncrement()
+	assert.Equal(suite.T(), "SERIAL", dialect.AutoIncrement(&col))
+
+	col = Column("autoinc", BigInt()).AutoIncrement()
+	assert.Equal(suite.T(), "BIGSERIAL", dialect.AutoIncrement(&col))
+
+	col = Column("autoinc", SmallInt()).AutoIncrement()
+	assert.Equal(suite.T(), "SMALLSERIAL", dialect.AutoIncrement(&col))
+
+}
+
 func (suite *PostgresTestSuite) TestPostgres() {
 	type User struct {
 		ID          string         `db:"id"`

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -19,7 +19,6 @@ func (suite *SqliteTestSuite) SetupTest() {
 	var err error
 
 	suite.engine, err = New("sqlite3", "./qb_test.db")
-	suite.engine.Logger().SetLogFlags(LQuery | LBindings)
 	suite.engine.Dialect().SetEscaping(true)
 
 	suite.metadata = MetaData()

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -157,6 +157,9 @@ func (suite *SqliteTestSuite) TestSqliteAutoIncrement() {
 	assert.Panics(suite.T(), func() {
 		col.String(suite.engine.Dialect())
 	})
+
+	col.Options.InlinePrimaryKey = true
+	assert.Equal(suite.T(), "INTEGER PRIMARY KEY", suite.engine.Dialect().AutoIncrement(&col))
 }
 
 func TestSqliteTestSuite(t *testing.T) {

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -31,6 +31,18 @@ func (suite *SqliteTestSuite) TestUUID() {
 	assert.Equal(suite.T(), "VARCHAR(36)", suite.engine.Dialect().CompileType(UUID()))
 }
 
+func (suite *SqliteTestSuite) TestDialect() {
+	dialect := NewDialect("sqlite")
+	assert.Equal(suite.T(), false, dialect.SupportsUnsigned())
+	assert.Equal(suite.T(), "test", dialect.Escape("test"))
+	assert.Equal(suite.T(), false, dialect.Escaping())
+	dialect.SetEscaping(true)
+	assert.Equal(suite.T(), true, dialect.Escaping())
+	assert.Equal(suite.T(), "\"test\"", dialect.Escape("test"))
+	assert.Equal(suite.T(), []string{"\"test\""}, dialect.EscapeAll([]string{"test"}))
+	assert.Equal(suite.T(), "sqlite3", dialect.Driver())
+}
+
 func (suite *SqliteTestSuite) TestSqlite() {
 	type User struct {
 		ID       string         `db:"id"`

--- a/type_test.go
+++ b/type_test.go
@@ -31,20 +31,18 @@ func (suite *TypeTestSuite) TestTypes() {
 	assert.Equal(suite.T(), "BLOB", dialect.CompileType(Blob()))
 }
 
-func TestTypeTestSuite(t *testing.T) {
-	suite.Run(t, new(TypeTestSuite))
+func (suite *TypeTestSuite) TestUnsigned() {
+	assert.Equal(suite.T(), "BIGINT", DefaultCompileType(BigInt().Signed(), true))
+	assert.Equal(suite.T(), "BIGINT UNSIGNED", DefaultCompileType(BigInt().Unsigned(), true))
+	assert.Equal(suite.T(), "NUMERIC(2, 5) UNSIGNED", DefaultCompileType(Numeric().Precision(2, 5).Unsigned(), true))
+
+	assert.Equal(suite.T(), "INT", DefaultCompileType(Int().Signed(), false))
+	assert.Equal(suite.T(), "SMALLINT", DefaultCompileType(TinyInt().Unsigned(), false))
+	assert.Equal(suite.T(), "INT", DefaultCompileType(SmallInt().Unsigned(), false))
+	assert.Equal(suite.T(), "BIGINT", DefaultCompileType(Int().Unsigned(), false))
+	assert.Equal(suite.T(), "BIGINT", DefaultCompileType(BigInt().Unsigned(), false))
 }
 
-func (suite *TypeTestSuite) TestUnsigned() {
-	dialect := NewDialect("mysql")
-	assert.Equal(suite.T(), "BIGINT", dialect.CompileType(BigInt().Signed()))
-	assert.Equal(suite.T(), "BIGINT UNSIGNED", dialect.CompileType(BigInt().Unsigned()))
-	assert.Equal(suite.T(), "NUMERIC(2, 5) UNSIGNED", dialect.CompileType(Numeric().Precision(2, 5).Unsigned()))
-
-	dialect = NewDialect("")
-	assert.Equal(suite.T(), "INT", dialect.CompileType(Int().Signed()))
-	assert.Equal(suite.T(), "SMALLINT", dialect.CompileType(TinyInt().Unsigned()))
-	assert.Equal(suite.T(), "INT", dialect.CompileType(SmallInt().Unsigned()))
-	assert.Equal(suite.T(), "BIGINT", dialect.CompileType(Int().Unsigned()))
-	assert.Equal(suite.T(), "BIGINT", dialect.CompileType(BigInt().Unsigned()))
+func TestTypeTestSuite(t *testing.T) {
+	suite.Run(t, new(TypeTestSuite))
 }

--- a/upsert_test.go
+++ b/upsert_test.go
@@ -7,15 +7,6 @@ import (
 )
 
 func TestUpsert(t *testing.T) {
-	sqlite := NewDialect("sqlite3")
-	sqlite.SetEscaping(true)
-
-	mysql := NewDialect("mysql")
-	mysql.SetEscaping(true)
-
-	postgres := NewDialect("postgres")
-	postgres.SetEscaping(true)
-
 	def := NewDialect("default")
 
 	users := Table(
@@ -25,8 +16,6 @@ func TestUpsert(t *testing.T) {
 		Column("created_at", Timestamp()).NotNull(),
 		PrimaryKey("id"),
 	)
-
-	var statement *Stmt
 
 	now := time.Now().UTC().String()
 
@@ -39,50 +28,4 @@ func TestUpsert(t *testing.T) {
 	assert.Panics(t, func() {
 		ups.Build(def)
 	})
-
-	statement = ups.Build(sqlite)
-	assert.Contains(t, statement.SQL(), `REPLACE INTO "users"`)
-	assert.Contains(t, statement.SQL(), "id", "email", "created_at")
-	assert.Contains(t, statement.SQL(), "VALUES(?, ?, ?)")
-	assert.Contains(t, statement.Bindings(), "9883cf81-3b56-4151-ae4e-3903c5bc436d")
-	assert.Contains(t, statement.Bindings(), "al@pacino.com")
-	assert.Contains(t, statement.Bindings(), now)
-	assert.Equal(t, 3, len(statement.Bindings()))
-
-	statement = ups.Build(mysql)
-	assert.Contains(t, statement.SQL(), "INSERT INTO `users`")
-	assert.Contains(t, statement.SQL(), "`id`", "`email`", "`created_at`")
-	assert.Contains(t, statement.SQL(), "VALUES(?, ?, ?)")
-	assert.Contains(t, statement.SQL(), "ON DUPLICATE KEY UPDATE")
-	assert.Contains(t, statement.SQL(), "`id` = ?", "`email` = ?", "`created_at` = ?")
-	assert.Contains(t, statement.Bindings(), "9883cf81-3b56-4151-ae4e-3903c5bc436d")
-	assert.Contains(t, statement.Bindings(), "al@pacino.com")
-	assert.Equal(t, 6, len(statement.Bindings()))
-
-	statement = ups.Build(postgres)
-	assert.Contains(t, statement.SQL(), "INSERT INTO \"users\"")
-	assert.Contains(t, statement.SQL(), "\"id\"", "\"email\"")
-	assert.Contains(t, statement.SQL(), "VALUES($1, $2, $3)")
-	assert.Contains(t, statement.SQL(), "ON CONFLICT", "DO UPDATE SET")
-	assert.Contains(t, statement.Bindings(), "9883cf81-3b56-4151-ae4e-3903c5bc436d")
-	assert.Contains(t, statement.Bindings(), "al@pacino.com")
-	assert.Equal(t, 6, len(statement.Bindings()))
-
-	statement = Upsert(users).
-		Values(map[string]interface{}{
-			"id":    "9883cf81-3b56-4151-ae4e-3903c5bc436d",
-			"email": "al@pacino.com",
-		}).
-		Returning(users.C("id"), users.C("email")).
-		Build(postgres)
-
-	assert.Contains(t, statement.SQL(), "INSERT INTO \"users\"")
-	assert.Contains(t, statement.SQL(), "\"id\"", "\"email\"")
-	assert.Contains(t, statement.SQL(), "ON CONFLICT")
-	assert.Contains(t, statement.SQL(), "DO UPDATE SET")
-	assert.Contains(t, statement.SQL(), "VALUES($1, $2)")
-	assert.Contains(t, statement.SQL(), "RETURNING \"id\", \"email\";")
-	assert.Contains(t, statement.Bindings(), "9883cf81-3b56-4151-ae4e-3903c5bc436d")
-	assert.Contains(t, statement.Bindings(), "al@pacino.com")
-	assert.Equal(t, 4, len(statement.Bindings()))
 }


### PR DESCRIPTION
Tests rely a lot on the dialects.
To prepare the dialect isolation in separate packages, we need not to rely on them.
This PR removes any dialect-specific tests from most _test.go files and add a few ones to the dialect tests.