### PR TITLE
Postgres errors are pointers

### DIFF
--- a/dialects/postgres/postgres.go
+++ b/dialects/postgres/postgres.go
@@ -86,7 +86,7 @@ func (d *PostgresDialect) GetCompiler() qb.Compiler {
 // WrapError wraps a native error in a qb Error
 func (d *PostgresDialect) WrapError(err error) (qbErr qb.Error) {
 	qbErr.Orig = err
-	pgErr, ok := err.(pq.Error)
+	pgErr, ok := err.(*pq.Error)
 	if !ok {
 		return
 	}

--- a/dialects/postgres/postgres_test.go
+++ b/dialects/postgres/postgres_test.go
@@ -96,7 +96,7 @@ func (suite *PostgresTestSuite) TestWrapError() {
 		{"ZZ000", qb.ErrDatabase},
 	} {
 		pgErr := pq.Error{Code: pq.ErrorCode(tt.pgCode)}
-		qbErr := dialect.WrapError(pgErr)
+		qbErr := dialect.WrapError(&pgErr)
 		assert.Equal(suite.T(), tt.qbCode, qbErr.Code)
 	}
 }


### PR DESCRIPTION
without this patch the type assertion always fails and the errors you receive from the postgres dialect always are ErrAny