### PR TITLE
Add a Unwrap() function to Error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -66,6 +66,10 @@ type Error struct {
 	Constraint string
 }
 
+func (err Error) Unwrap() error {
+	return err.Orig
+}
+
 func (err Error) Error() string {
 	switch err.Code {
 	case ErrAny:


### PR DESCRIPTION
It allows using errors.Is and errors.As in the calling code